### PR TITLE
docs: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: "Bug Report"
+about: "Report a reproducible bug"
+title: "[BUG] "
+labels: ["bug"]
+---
+
+## Description
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Environment Info
+- OS: [e.g. Windows 11]
+- Version: [e.g. 1.0.0]
+- Browser/Tool: [e.g. Chrome, VS Code]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: "Feature Request"
+about: "Suggest an idea for this project"
+title: "[FEATURE] "
+labels: ["enhancement"]
+---
+
+## Problem Statement
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What does this PR do?
+[Provide a summary of the changes]
+
+## Related issue
+[Link to the issue, e.g. #123]
+
+## Testing done
+[Describe the tests you ran to verify your changes]
+
+## Checklist
+- [ ] I have run `cargo fmt` (or equivalent formatter)
+- [ ] I have run `cargo clippy` (or equivalent linter)
+- [ ] All tests pass locally
+- [ ] I have labeled this PR with 'good first issue' or 'dx' where applicable.


### PR DESCRIPTION
Closes #27

---

Description
This PR introduces standardized GitHub templates to the repository to improve the quality and consistency of community contributions.

Changes included:

Pull Request Template: Added a structured format for contributors to describe their changes, link issues, and provide a testing checklist.

Issue Templates: (If applicable) Created templates for Bug Reports and Feature Requests to ensure all necessary technical details are captured upfront.

Why is this necessary?
As the project grows, having these templates ensures that every contribution follows a consistent standard, making it easier for maintainers to review and merge code efficiently.

How to test?
Navigate to the "Pull Requests" tab.

Click "New pull request".

The new template should automatically populate the description field.