### PR TITLE
docs: add CHANGELOG.md following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### forge-vesting
+
+- `initialize(token, beneficiary, admin, total_amount, cliff_seconds, duration_seconds)` — deploy a linear vesting schedule with an optional cliff period
+- `claim()` — withdraw all currently unlocked tokens (beneficiary only)
+- `cancel()` — cancel vesting and return unvested tokens to admin (admin only)
+- `get_status()` — returns `VestingStatus` with total, claimed, vested, claimable amounts, cliff status, and fully-vested flag
+- `get_config()` — returns the full `VestingConfig`
+- Events: `vesting_initialized`, `claimed`, `vesting_cancelled`
+
+### forge-stream
+
+- `create_stream(sender, token, recipient, rate_per_second, duration_seconds)` — start a pay-per-second token stream; pulls total tokens from sender upfront
+- `withdraw(stream_id)` — withdraw all accrued tokens (recipient only)
+- `cancel_stream(stream_id)` — cancel stream, pay out accrued tokens to recipient, return remainder to sender (sender only)
+- `get_stream(stream_id)` — returns full `Stream` data
+- `get_stream_status(stream_id)` — returns `StreamStatus` with streamed, withdrawn, withdrawable, remaining amounts, and active/finished flags
+- Events: `stream_created`, `withdrawn`, `stream_cancelled`
+
+### forge-multisig
+
+- `initialize(owners, threshold, timelock_delay)` — set up an N-of-M multisig treasury
+- `propose(proposer, to, token, amount)` — propose a token transfer (owners only)
+- `approve(owner, proposal_id)` — approve a proposal; starts timelock when threshold is reached
+- `reject(owner, proposal_id)` — reject a proposal (owners only)
+- `execute(executor, proposal_id)` — execute an approved proposal after the timelock delay
+- `get_proposal(proposal_id)` — returns `Proposal` data
+- `get_owners()` — returns the list of owner addresses
+- `get_threshold()` — returns the approval threshold
+
+### forge-governor
+
+- `initialize(config)` — configure the governor with vote token, voting period, quorum, and timelock delay
+- `propose(proposer, title, description)` — create a governance proposal; returns proposal ID
+- `vote(voter, proposal_id, support, weight)` — cast a token-weighted vote
+- `finalize(proposal_id)` — finalize a proposal after voting ends; sets state to `Passed` or `Failed`
+- `execute(executor, proposal_id)` — mark a passed proposal as executed after the timelock
+- `get_proposal(proposal_id)` — returns `Proposal` data
+- `get_config()` — returns `GovernorConfig`
+- `has_voted(proposal_id, voter)` — returns whether an address has voted on a proposal
+
+### forge-oracle
+
+- `initialize(admin, staleness_threshold)` — set up the oracle with an admin and staleness window
+- `submit_price(base, quote, price)` — submit a price for a trading pair (admin only); price scaled to 7 decimals
+- `get_price(base, quote)` — returns `PriceData`; reverts with `PriceStale` if data exceeds the staleness threshold
+- `get_price_unsafe(base, quote)` — returns `PriceData` without staleness check
+- `set_staleness_threshold(new_threshold)` — update the staleness window (admin only)
+- `transfer_admin(new_admin)` — transfer admin role to a new address
+- `get_admin()` — returns the current admin address
+- Events: `price_updated`


### PR DESCRIPTION
Overview
The task was to resolve a missing CHANGELOG.md in the StellarForge repository. Downstream users and auditors had no way to track what changed between releases. The goal was to create a CHANGELOG.md at the repo root following the Keep a Changelog format, with an initial [Unreleased] section documenting the current state of all five contract interfaces.

Step 1: Understanding the Codebase
Before writing a single line of the changelog, all five contract source files were read in full:

lib.rs
lib.rs
lib.rs
lib.rs
lib.rs
For each contract, the following were extracted:

Every public function exposed via #[contractimpl]
The full parameter signatures
Return types and error variants
Events emitted via env.events().publish(...)
This was necessary to ensure the [Unreleased] section was accurate and complete — not a guess or a copy-paste from the README, but a direct reflection of what the contracts actually expose.

Step 2: Authoring the CHANGELOG.md
The file was structured according to the Keep a Changelog 1.1.0 spec:

A header linking to https://keepachangelog.com/en/1.1.0/
A single [Unreleased] section (no version tag yet, since no release has been cut)
Each contract documented under its own named subsection
For each contract, every public function was listed with a short description of what it does, who can call it, and what it returns or emits. Specifically:

forge-vesting — 5 functions documented: initialize, claim, cancel, get_status, get_config, plus 3 events (vesting_initialized, claimed, vesting_cancelled).

forge-stream — 5 functions documented: create_stream, withdraw, cancel_stream, get_stream, get_stream_status, plus 3 events (stream_created, withdrawn, stream_cancelled).

forge-multisig — 7 functions documented: initialize, propose, approve, reject, execute, get_proposal, get_owners, get_threshold.

forge-governor — 7 functions documented: initialize, propose, vote, finalize, execute, get_proposal, get_config, has_voted.

forge-oracle — 7 functions documented: initialize, submit_price, get_price, get_price_unsafe, set_staleness_threshold, transfer_admin, get_admin, plus 1 event (price_updated).

Step 3: Git Workflow
Branch creation — a dedicated branch docs/add-changelog was created off main to isolate the change:

git checkout -b docs/add-changelog
Staging — only CHANGELOG.md was staged. The spec files (.kiro/specs/...) that were sitting in the working tree were deliberately excluded to keep the PR clean and scoped to the issue:

git add CHANGELOG.md
An earlier attempt accidentally swept in the spec files because they had been staged from a previous session. This was caught, the commit was reset with git reset HEAD~1, and only CHANGELOG.md was re-staged before recommitting.

Commit — a conventional commit message was used:

docs: add CHANGELOG.md following Keep a Changelog format
Push — the branch was pushed to the remote and tracked:

git push -u origin docs/add-changelog
GitHub confirmed the branch was created and provided the PR URL: https://github.com/darcszn/stellarforge/pull/new/docs/add-changelog

Checkout — after the push, the working branch was switched back to main to leave the repo in a clean state for the next issue:

git checkout main
What Was Not Done (intentionally)
No spec files, design docs, or task lists were included in the commit — the issue asked only for CHANGELOG.md.
README.md was not modified — unlike the CONTRIBUTING issue, this task had no requirement to update the README.
No CI configuration, build scripts, or source code was touched.
Result
A single file, CHANGELOG.md, was added to the repository root. It is immediately useful to auditors and downstream users as a reference for the current contract surface area, and it establishes the changelog convention for all future releases.

Closes #29 