### PR TITLE
feat:add makefile with common dev commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Makefile for StellarForge
+
+# Default target
+.PHONY: all
+all: check
+
+# Build all workspace crates
+.PHONY: build
+build:
+	cargo build --workspace
+
+# Run all tests
+.PHONY: test
+test:
+	cargo test --workspace
+
+# Run clippy linter with deny warnings
+.PHONY: lint
+lint:
+	cargo clippy --all-targets -- -D warnings
+
+# Format code
+.PHONY: fmt
+fmt:
+	cargo fmt --all
+
+# Run fmt, lint, and test in sequence
+.PHONY: check
+check: fmt lint test
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -82,9 +82,23 @@ Before deploying, you'll need a funded testnet account. You can generate and fun
 stellar keys generate <identity_name> --network testnet --fund
 ```
 
+### Using Make (Recommended)
+This project includes a Makefile with common development commands:
+
+| Command | Description |
+| :--- | :--- |
+| `make build` | Build all workspace crates |
+| `make test` | Run all tests |
+| `make lint` | Run clippy linter with deny warnings |
+| `make fmt` | Format code |
+| `make check` | Run fmt + lint + test in sequence |
+| `make clean` | Clean build artifacts |
+
 ### Build all contracts
 
 ```bash
+make build
+# or manually:
 cargo build --workspace
 stellar contract build
 ```
@@ -92,6 +106,8 @@ stellar contract build
 ### Run all tests
 
 ```bash
+make test
+# or manually:
 cargo test --workspace
 ```
 


### PR DESCRIPTION
- Add Makefile with build, test, lint, fmt, check, and clean commands
- Update README to reference Makefile in Getting Started section

Closes #26

# Add admin transfer function to forge-vesting

closes #26 
## Summary
Implements the `transfer_admin` function in the forge-vesting contract to allow transferring admin rights to a new address.

## Changes Made
- Added `SameAdmin` error variant in `VestingError` enum
- Implemented `transfer_admin(new_admin: Address)` function in `forge-vesting` contract:
  - Requires authorization from current admin
  - Prevents transferring to the same admin
  - Emits `admin_transferred` event on successful transfer
- Added tests:
  - `test_transfer_admin_success` - verifies admin can be transferred to a new address
  - `test_transfer_admin_by_non_admin_fails` - verifies unauthorized calls fail
  - `test_transfer_admin_to_same_admin_fails` - verifies transferring to same admin fails

## Checklist
- [x] Implementation complete
- [x] Tests added
- [ ] Documentation updated
- [ ] No sensitive information included

## Testing
Tests can be run with: `cargo test --package forge-vesting`
