### PR TITLE
Add GitHub Discussions link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ Each contract in StellarForge is versioned independently. A breaking change in `
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style requirements, and the pull request process.
 
+## Community & Discussions
+
+Have a question, idea, or something to share? Join the conversation in [GitHub Discussions](https://github.com/soma-enyi/stellarforge/discussions) — we have dedicated spaces for Q&A, ideas, show-and-tell, and general chat.
+
 ---
 
 ## License


### PR DESCRIPTION
Closes #89


> Enable GitHub Discussions and add community link to README

## What

- Adds a Community & Discussions section to the README with a direct link to GitHub Discussions
- The remaining setup tasks (enabling Discussions in repo settings, creating categories, 
pinning a welcome post) require the GitHub UI and are documented below

## Manual steps to complete this issue

Once this PR is merged, a maintainer should:

1. Settings → General → Features → check Discussions → Save
2. Discussions tab → Edit categories → create: Q&A, Ideas, Show and Tell, General
3. Create a new Discussion in General with a welcome post introducing the project and inviting
contributions → pin it

## Why

Developers integrating StellarForge currently have no dedicated space for questions or 
feedback outside of opening issues. Discussions provides a lower-friction channel for Q&A, 
ideas, and community show-and-tell, which is already referenced in the README.
