### PR TITLE
docs: add pre-commit hook setup guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,70 @@ This must produce zero warnings.
 
 ---
 
+## Pre-Commit Hook (Optional but Recommended)
+
+A pre-commit hook can automatically check formatting and linting before each commit, catching issues early and saving CI time.
+
+### Setting Up the Hook
+
+**Quick Setup** (using the provided template):
+
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+**Manual Setup**:
+
+1. Create the hook file:
+
+```bash
+touch .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+2. Add the following script to `.git/hooks/pre-commit`:
+
+```bash
+#!/bin/bash
+
+echo "Running pre-commit checks..."
+
+# Check formatting
+echo "Checking code formatting..."
+if ! cargo fmt --all -- --check; then
+    echo "❌ Code formatting check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+fi
+
+# Run clippy
+echo "Running clippy..."
+if ! cargo clippy --all-targets -- -D warnings; then
+    echo "❌ Clippy found issues. Fix them before committing."
+    exit 1
+fi
+
+# Run tests (optional - can be slow for large projects)
+# Uncomment the following lines if you want to run tests before each commit:
+# echo "Running tests..."
+# if ! cargo test --workspace; then
+#     echo "❌ Tests failed. Fix them before committing."
+#     exit 1
+# fi
+
+echo "✅ All pre-commit checks passed!"
+exit 0
+```
+
+### Notes
+
+- The hook is **optional** but highly recommended to catch issues before pushing
+- If you need to bypass the hook in an emergency, use `git commit --no-verify`
+- The test step is commented out by default since it can be slow; uncomment if desired
+- Each contributor must set up the hook individually (hooks are not tracked by git)
+
+---
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch off `main`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# Scripts
+
+This directory contains helper scripts for contributors.
+
+## pre-commit
+
+A git pre-commit hook that automatically checks code formatting and linting before each commit.
+
+### Installation
+
+```bash
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#pre-commit-hook-optional-but-recommended) for more details.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Running pre-commit checks..."
+
+# Check formatting
+echo "Checking code formatting..."
+if ! cargo fmt --all -- --check; then
+    echo "❌ Code formatting check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+fi
+
+# Run clippy
+echo "Running clippy..."
+if ! cargo clippy --all-targets -- -D warnings; then
+    echo "❌ Clippy found issues. Fix them before committing."
+    exit 1
+fi
+
+# Run tests (optional - can be slow for large projects)
+# Uncomment the following lines if you want to run tests before each commit:
+# echo "Running tests..."
+# if ! cargo test --workspace; then
+#     echo "❌ Tests failed. Fix them before committing."
+#     exit 1
+# fi
+
+echo "✅ All pre-commit checks passed!"
+exit 0


### PR DESCRIPTION
## What does this PR do?

Adds a comprehensive pre-commit hook setup guide to CONTRIBUTING.md to help contributors catch formatting and linting issues before committing, reducing CI failures and review cycles.

The PR includes:
- **Documentation in CONTRIBUTING.md**: Step-by-step instructions for setting up a git pre-commit hook
- **Template hook script**: Ready-to-use `scripts/pre-commit` file that contributors can copy directly
- **Quick setup option**: One-liner command to install the hook
- **Manual setup instructions**: For contributors who want to customize the hook

The pre-commit hook automatically runs:
- `cargo fmt --all -- --check` to validate code formatting
- `cargo clippy --all-targets -- -D warnings` to catch linting issues
- Optional test runner (commented out by default for performance)

## Related issue

This PR closes #103 

## Testing done

- Verified the pre-commit hook script has valid bash syntax using `bash -n scripts/pre-commit`
- Tested the hook by running `./scripts/pre-commit` to confirm it correctly:
  - Detects formatting issues
  - Runs clippy checks
  - Provides clear error messages
  - Exits with appropriate status codes
- Confirmed the quick setup command works: `cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`
- Verified markdown formatting in CONTRIBUTING.md is correct
- Tested that the hook can be bypassed with `git commit --no-verify` when needed

## Checklist

- [x] I have run `cargo fmt` (or equivalent formatter)
- [x] I have run `cargo clippy` (or equivalent linter)
- [x] All tests pass locally
- [x] I have labeled this PR with 'good first issue' or 'dx' where applicable.
