### PR TITLE
Add .editorconfig for consistent formatting across editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps maintain consistent coding styles
+# across different editors and IDEs
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Add .editorconfig for consistent formatting across editors

- Set indent style to spaces, indent size to 4 (Rust convention)
- Set end of line to lf
- Set charset to utf-8
- Enable trim_trailing_whitespace and insert_final_newline
closes #41 