### PR TITLE
Add explicit PriceNotFound tests for unsubmitted pairs

### DIFF
--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -404,6 +404,42 @@ mod tests {
     }
 
     #[test]
+    fn test_get_price_unsubmitted_pair_reverts_with_price_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client) = setup(&env);
+
+        // Use a pair that has never had a price submitted
+        let base = Symbol::new(&env, "ETH");
+        let quote = Symbol::new(&env, "USDC");
+
+        let result = client.try_get_price(&base, &quote);
+        assert_eq!(
+            result,
+            Err(Ok(OracleError::PriceNotFound)),
+            "get_price() on an unsubmitted pair must revert with PriceNotFound"
+        );
+    }
+
+    #[test]
+    fn test_get_price_unsafe_unsubmitted_pair_reverts_with_price_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client) = setup(&env);
+
+        // Use a pair that has never had a price submitted
+        let base = Symbol::new(&env, "ETH");
+        let quote = Symbol::new(&env, "USDC");
+
+        let result = client.try_get_price_unsafe(&base, &quote);
+        assert_eq!(
+            result,
+            Err(Ok(OracleError::PriceNotFound)),
+            "get_price_unsafe() on an unsubmitted pair must revert with PriceNotFound"
+        );
+    }
+
+    #[test]
     fn test_invalid_price_rejected() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
## Summary

this pr Closes #146 

What
Adds two explicit tests to forge-oracle covering the case where get_price() and get_price_unsafe() are called for a pair that has never had a price submitted.

Why
Previously there was no dedicated test asserting the exact error returned in this scenario. These tests make the contract's failure behavior explicit and guard against regressions.

Tests added
test_get_price_unsubmitted_pair_reverts_with_price_not_found
test_get_price_unsafe_unsubmitted_pair_reverts_with_price_not_found
Both assert OracleError::PriceNotFound is returned when querying a pair with no prior price submission.

To actually open the PR, push your branch and run:

gh pr create --title "test(forge-oracle): add explicit PriceNotFoun