### PR TITLE
Add unauthorized withdraw tests for non-recipient and sender

### DIFF
--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -1287,6 +1287,75 @@ mod tests {
     }
 
     #[test]
+    fn test_random_address_cannot_withdraw() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let intruder = Address::generate(&env);
+        let token = make_token(&env, &contract_id, &sender, 100_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+
+        // Advance time so tokens have accrued
+        env.ledger().with_mut(|l| l.timestamp = 500);
+
+        // Mock auth as the intruder, not the recipient
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &intruder,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "withdraw",
+                args: (stream_id,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        let result = client.try_withdraw(&stream_id);
+        assert!(
+            result.is_err(),
+            "Expected withdraw by random address to revert"
+        );
+    }
+
+    #[test]
+    fn test_sender_cannot_withdraw() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = make_token(&env, &contract_id, &sender, 100_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+
+        // Advance time so tokens have accrued
+        env.ledger().with_mut(|l| l.timestamp = 500);
+
+        // Mock auth as the sender, not the recipient
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &sender,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "withdraw",
+                args: (stream_id,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        let result = client.try_withdraw(&stream_id);
+        assert!(
+            result.is_err(),
+            "Expected withdraw by sender to revert with Unauthorized"
+        );
+    }
+
+    #[test]
     fn test_get_stream_count_starts_at_zero() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
## Summary

This PR adds explicit test coverage for unauthorized access to the withdraw() function in the forge-stream contract. The contract enforces that only the designated recipient of a stream can call withdraw(). Previously, there were no dedicated tests asserting this access control behavior for both a random third-party address and the stream's own sender. This PR closes that gap.

this pr Closes #145 

### Background

The withdraw() function in ForgeStream calls stream.recipient.require_auth() before processing any token transfer. This means any caller that is not the recipient should be rejected at the host level. While this is a core security invariant of the contract, it was not explicitly tested, leaving room for regressions if the auth check were accidentally removed or moved.

The two scenarios that needed coverage were:

- A completely unrelated address (intruder) attempting to drain a stream they have no relation to
- 
- The stream's own sender attempting to withdraw — they funded the stream but are explicitly not authorized to pull tokens out

Changes
lib.rs

Added two new test functions inside the existing #[cfg(test)] module:

test_random_address_cannot_withdraw

- Creates a stream between a sender and recipient
- Generates a third intruder address with no relation to the stream
- Advances ledger time so tokens have accrued and a withdrawal would otherwise succeed
- Mocks auth as the intruder and calls try_withdraw()
- Asserts the call reverts, confirming the auth guard blocks unrelated callers

test_sender_cannot_withdraw

- Creates a stream between a sender and recipient
- Advances ledger time so tokens have accrued
- Mocks auth as the sender (who funded the stream) and calls try_withdraw()
- Asserts the call reverts, confirming that funding a stream does not grant withdrawal rights

### Why This Matters

Access control bugs are among the most critical vulnerabilities in smart contracts. A missing or misconfigured auth check on withdraw() could allow anyone to drain tokens from any stream. These tests act as a regression guard — if the require_auth() check is ever accidentally removed or weakened, the test suite will catch it immediately.

How to Verify
Run the full oracle test suite locally:

cargo test -p forge-stream
All existing tests should continue to pass, and the two new tests should pass as well.