### PR TITLE
Add test for forge-multisig execute() transferring correct token

### DIFF
--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -1087,4 +1087,64 @@ mod tests {
         // Approval count for a non-existent proposal returns 0
         assert_eq!(client.get_approval_count(&0), 0);
     }
+
+    // ── Token balance verification after execute() ────────────────────────────
+
+    /// After a proposal is approved, the timelock elapses, and execute() is called,
+    /// the recipient's token balance must increase by exactly the proposed amount,
+    /// and the multisig contract's balance must decrease by the same amount.
+    #[test]
+    fn test_execute_transfers_exact_token_amount_to_recipient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+
+        // Step 1: Fund the multisig contract with tokens
+        const TIMELOCK: u64 = 3600;
+        const TRANSFER_AMOUNT: i128 = 250;
+        const FUNDED_AMOUNT: i128 = 1000;
+
+        let (client, [o1, o2, o3], token_id, recipient, contract_id) =
+            setup_funded(&env, TIMELOCK);
+
+        let token = soroban_sdk::token::Client::new(&env, &token_id);
+
+        // Verify initial balances
+        let initial_contract_balance = token.balance(&contract_id);
+        let initial_recipient_balance = token.balance(&recipient);
+        assert_eq!(initial_contract_balance, FUNDED_AMOUNT);
+        assert_eq!(initial_recipient_balance, 0);
+
+        // Step 2: Propose a transfer of a specific amount to the recipient
+        let pid = client.propose(&o1, &recipient, &token_id, &TRANSFER_AMOUNT);
+
+        // Step 3: Approve to reach the 2-of-3 threshold
+        client.approve(&o2, &pid);
+
+        // Step 4: Advance past the timelock and execute
+        env.ledger().with_mut(|l| l.timestamp = TIMELOCK + 1);
+        client.execute(&o3, &pid);
+
+        // Step 5: Verify recipient balance increased by exactly the proposed amount
+        let final_recipient_balance = token.balance(&recipient);
+        assert_eq!(
+            final_recipient_balance,
+            initial_recipient_balance + TRANSFER_AMOUNT,
+            "recipient balance must increase by exactly the proposed amount"
+        );
+
+        // Step 6: Verify multisig balance decreased by the same amount
+        let final_contract_balance = token.balance(&contract_id);
+        assert_eq!(
+            final_contract_balance,
+            initial_contract_balance - TRANSFER_AMOUNT,
+            "multisig balance must decrease by exactly the proposed amount"
+        );
+
+        // Sanity check: no tokens created or destroyed
+        assert_eq!(
+            final_recipient_balance + final_contract_balance,
+            FUNDED_AMOUNT
+        );
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds an explicit end-to-end test for the execute() function in the forge-multisig contract that verifies token balances are transferred correctly. While existing tests confirm that execute() marks a proposal as executed and respects the timelock, none of them assert the actual on-chain token movement — specifically that the recipient receives exactly the proposed amount and the multisig contract loses exactly that same amount. This PR closes that gap.

this pr Closes #148 

### Changes

lib.rs
Added one new test: test_execute_transfers_exact_token_amount_to_recipient

The test follows the full happy-path flow described in the issue:

- Fund the multisig contract with 1000 tokens using the existing setup_funded helper
- Record initial balances for both the contract and the recipient (recipient starts at 0)
- Propose a transfer of exactly 250 tokens to the recipient
- Approve the proposal with a second owner to reach the 2-of-3 threshold
- Advance the ledger past the timelock delay

Call execute() and assert:

- Recipient balance increased by exactly 250
- Contract balance decreased by exactly 250
- Total supply is conserved (no tokens created or destroyed)

### Why This Matters

Token balance assertions are the ground truth for any treasury contract. A test that only checks proposal.executed is testing state, not behavior. This test checks both — it confirms the state machine advanced AND that the economic outcome is correct. It would catch bugs like:

- Transferring to the wrong address
- Transferring the wrong amount
- Transferring twice (double-spend)
- Not transferring at all despite marking as executed

### How to Verify

cargo test -p forge-multisig
All existing tests should continue to pass alongside the new one.

### Checklist

- [x]  Multisig contract funded with tokens before proposal
- [x]  Specific transfer amount proposed and tracked
- [x]  Proposal approved to threshold and executed after timelock
- [x]  Recipient balance verified to increase by exact proposed amount
- [x]  Contract balance verified to decrease by exact proposed amount
- [x]  Token conservation invariant asserted (no tokens lost or created)
- [x]  No changes to contract logic, only test coverage