### PR TITLE
Add test for forge-governor where yes and no votes are equal

### DIFF
--- a/contracts/forge-governor/README.md
+++ b/contracts/forge-governor/README.md
@@ -6,33 +6,35 @@
 
 ### Function Resource Estimates
 
-| Function | CPU Instructions | Memory (bytes) | Ledger Reads | Ledger Writes | Notes |
-| :--- | :---: | :---: | :---: | :---: | :--- |
-| `initialize` | ~50,000 | ~2,000 | 0 | 2 | Stores admin and config |
-| `propose` | ~80,000 | ~3,000 | 2 | 3 | Validates proposer, creates proposal |
-| `vote` | ~60,000 | ~2,500 | 3 | 2 | Updates vote tally, records voter |
-| `execute` | ~100,000 | ~3,500 | 4 | 2 | Most expensive - validates quorum, checks timelock, executes proposal |
-| `get_proposal` | ~20,000 | ~1,500 | 2 | 0 | Read-only query |
-| `get_vote` | ~15,000 | ~1,000 | 1 | 0 | Read-only query |
+| Function       | CPU Instructions | Memory (bytes) | Ledger Reads | Ledger Writes | Notes                                                                 |
+| :------------- | :--------------: | :------------: | :----------: | :-----------: | :-------------------------------------------------------------------- |
+| `initialize`   |     ~50,000      |     ~2,000     |      0       |       2       | Stores admin and config                                               |
+| `propose`      |     ~80,000      |     ~3,000     |      2       |       3       | Validates proposer, creates proposal                                  |
+| `vote`         |     ~60,000      |     ~2,500     |      3       |       2       | Updates vote tally, records voter                                     |
+| `execute`      |     ~100,000     |     ~3,500     |      4       |       2       | Most expensive - validates quorum, checks timelock, executes proposal |
+| `get_proposal` |     ~20,000      |     ~1,500     |      2       |       0       | Read-only query                                                       |
+| `get_vote`     |     ~15,000      |     ~1,000     |      1       |       0       | Read-only query                                                       |
 
 ### Most Expensive Functions
 
 1. **`execute`** (~100,000 CPU instructions)
-   - Why: Validates quorum requirements, checks timelock expiration, and executes the proposal action
-   - Optimization tip: Ensure proposals are well-formed before submission to avoid failed executions
+    - Why: Validates quorum requirements, checks timelock expiration, and executes the proposal action
+    - Optimization tip: Ensure proposals are well-formed before submission to avoid failed executions
 
 2. **`propose`** (~80,000 CPU instructions)
-   - Why: Validates proposer eligibility, creates new proposal storage, and initializes vote tracking
-   - Optimization tip: Reuse proposal templates for similar governance actions
+    - Why: Validates proposer eligibility, creates new proposal storage, and initializes vote tracking
+    - Optimization tip: Reuse proposal templates for similar governance actions
 
 ### Cost Estimation
 
 Soroban charges fees based on:
+
 - **CPU Instructions:** ~0.0001 XLM per 10,000 instructions
 - **Memory:** ~0.00001 XLM per byte
 - **Ledger Entries:** ~0.001 XLM per read/write
 
 **Example:** Executing a proposal costs approximately:
+
 - CPU: 100,000 instructions × 0.0001 XLM / 10,000 = 0.001 XLM
 - Memory: 3,500 bytes × 0.00001 XLM = 0.035 XLM
 - Ledger: 6 operations × 0.001 XLM = 0.006 XLM
@@ -43,3 +45,28 @@ Soroban charges fees based on:
 ## Known Limitations
 
 - No vote delegation
+
+---
+
+## Tie-Breaking Behaviour
+
+When `finalize()` is called after the voting period ends, the contract requires a **strict majority** to pass a proposal:
+
+```
+votes_for > votes_against
+```
+
+If `votes_for == votes_against` (a tie), the proposal resolves to **`Failed`**. There is no mechanism that breaks a tie in favour of the proposer, the quorum, or any other party. This behaviour is deterministic and unconditional.
+
+### Summary table
+
+| Condition                                                | Outcome  |
+| :------------------------------------------------------- | :------- |
+| `total_votes < quorum`                                   | `Failed` |
+| `total_votes >= quorum` and `votes_for > votes_against`  | `Passed` |
+| `total_votes >= quorum` and `votes_for == votes_against` | `Failed` |
+| `total_votes >= quorum` and `votes_for < votes_against`  | `Failed` |
+
+### Rationale
+
+Requiring a strict majority means the status quo is preserved on a tie. A proposal must actively win — not merely draw — to advance to execution. This is the safest default for an on-chain treasury governor where an ambiguous outcome should never result in a token transfer.

--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -1044,4 +1044,107 @@ mod tests {
         assert_eq!(pending.get(0).unwrap(), pid1);
         assert_eq!(pending.get(1).unwrap(), pid2);
     }
+
+    // ── Tie-breaking behaviour ─────────────────────────────────────────────────
+    //
+    // The contract requires votes_for > votes_against (strict majority) to pass.
+    // When yes votes equal no votes the proposal resolves to Failed — there is
+    // no mechanism that breaks a tie in favour of the proposer or any other party.
+    // This is deterministic and must be explicitly tested.
+
+    /// Equal yes and no votes that together meet quorum must resolve to Failed.
+    /// Tie-breaking rule: votes_for must be strictly greater than votes_against.
+    #[test]
+    fn test_tied_vote_resolves_to_failed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = setup(&env); // quorum = 100, voting_period = 3600
+
+        let proposer = Address::generate(&env);
+        let yes_voter = Address::generate(&env);
+        let no_voter = Address::generate(&env);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Tied Proposal"),
+            &String::from_str(&env, "Equal yes and no votes"),
+        );
+
+        // Cast equal weight on both sides — total = 200, meets quorum of 100
+        client.vote(&yes_voter, &pid, &true, &100);
+        client.vote(&no_voter, &pid, &false, &100);
+
+        // Advance past the voting period
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        let state = client.finalize(&pid);
+
+        // Tie must resolve to Failed — strict majority (votes_for > votes_against) required
+        assert_eq!(
+            state,
+            ProposalState::Failed,
+            "a tied vote must resolve to Failed, not Passed"
+        );
+
+        // Confirm the stored state matches
+        let proposal = client.get_proposal(&pid);
+        assert_eq!(proposal.state, ProposalState::Failed);
+        assert_eq!(proposal.votes_for, 100);
+        assert_eq!(proposal.votes_against, 100);
+        assert!(proposal.passed_at.is_none(), "passed_at must not be set on a failed proposal");
+    }
+
+    /// One extra no vote tips a near-tie to Failed.
+    #[test]
+    fn test_near_tie_no_majority_resolves_to_failed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let yes_voter = Address::generate(&env);
+        let no_voter = Address::generate(&env);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Near-tie Proposal"),
+            &String::from_str(&env, "No votes exceed yes by 1"),
+        );
+
+        // 100 yes, 101 no — quorum met, but no majority
+        client.vote(&yes_voter, &pid, &true, &100);
+        client.vote(&no_voter, &pid, &false, &101);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        let state = client.finalize(&pid);
+        assert_eq!(state, ProposalState::Failed);
+    }
+
+    /// One extra yes vote tips a near-tie to Passed.
+    #[test]
+    fn test_near_tie_yes_majority_resolves_to_passed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let yes_voter = Address::generate(&env);
+        let no_voter = Address::generate(&env);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Near-tie Proposal"),
+            &String::from_str(&env, "Yes votes exceed no by 1"),
+        );
+
+        // 101 yes, 100 no — quorum met, strict majority achieved
+        client.vote(&yes_voter, &pid, &true, &101);
+        client.vote(&no_voter, &pid, &false, &100);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        let state = client.finalize(&pid);
+        assert_eq!(state, ProposalState::Passed);
+    }
 }


### PR DESCRIPTION
## Summary

This PR closes a critical gap in governance predictability by codifying tie-breaking behavior in the forge-governor module. When “yes” and “no” votes reach equilibrium, the system must not drift into ambiguity — it must resolve with intent.

### What’s shipped

- Added a test case that simulates a proposal reaching quorum with equal “yes” and “no” votes
- Invoked finalize() to assert the outcome aligns with the contract’s tie-breaking rule
- Validated deterministic resolution to eliminate edge-case uncertainty

### Why this matters

In governance systems, undefined edges are attack surfaces. A tied vote without a clear outcome introduces inconsistency, weakens trust, and creates room for exploitation. This PR locks that door.

### Impact

- Strengthens contract reliability
- Improves test coverage on critical decision paths
- Aligns implementation with governance expectations

this pr Closes #144 