### PR TITLE
fix(forge-oracle): emit admin_transferred event in transfer_admin

### DIFF
--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -252,7 +252,14 @@ impl ForgeOracle {
             .get(&DataKey::Admin)
             .ok_or(OracleError::NotInitialized)?;
         admin.require_auth();
+        let old_admin = admin.clone();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin_transferred"),),
+            (old_admin, new_admin),
+        );
+
         Ok(())
     }
 
@@ -468,6 +475,30 @@ mod tests {
         let new_admin = Address::generate(&env);
         client.transfer_admin(&new_admin);
         assert_eq!(client.get_admin().unwrap(), new_admin);
+    }
+
+    #[test]
+    fn test_transfer_admin_emits_event() {
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let (old_admin, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+
+        client.transfer_admin(&new_admin);
+
+        let events = env.events().all();
+        let found = events.iter().any(|(_, topics, data)| {
+            topics
+                .get(0)
+                .and_then(|t| Symbol::try_from_val(&env, &t).ok())
+                .map(|s| s == Symbol::new(&env, "admin_transferred"))
+                .unwrap_or(false)
+                && <(Address, Address)>::try_from_val(&env, &data)
+                    .map(|(old, new)| old == old_admin && new == new_admin)
+                    .unwrap_or(false)
+        });
+        assert!(found, "Expected admin_transferred event not found");
     }
 
     #[test]


### PR DESCRIPTION


closes #196 


Admin transfers are critical security events. Without an event, off-chain monitoring systems cannot detect a compromised admin key silently transferring control.

- Capture old_admin before overwriting storage
- Emit (admin_transferred,) topic with (old_admin, new_admin) data, matching the pattern used in submit_price()
- Add test_transfer_admin_emits_event() verifying topic and addresses

Fixes: #security/transfer-admin-no-event
Labels: bug, forge-oracle, security

## What does this PR do?
[Provide a summary of the changes]

## Related issue
[Link to the issue, e.g. #123]

## Testing done
[Describe the tests you ran to verify your changes]

## Checklist
- [  ] I have run `cargo fmt` (or equivalent formatter)
- [  ] I have run `cargo clippy` (or equivalent linter)
- [  ] All tests pass locally
- [  ] I have labeled this PR with 'good first issue' or 'dx' where applicable.
