### PR TITLE
feat: add view functions for #149, #150, #151, #152

### DIFF
--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -50,6 +50,18 @@ pub enum ProposalState {
     Cancelled,
 }
 
+/// Vote tally for a proposal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct VoteTally {
+    /// Total votes cast in favor.
+    pub yes_votes: i128,
+    /// Total votes cast against.
+    pub no_votes: i128,
+    /// Sum of yes and no votes.
+    pub total_votes: i128,
+}
+
 /// A governance proposal.
 #[contracttype]
 #[derive(Clone)]
@@ -518,6 +530,67 @@ impl GovernorContract {
         env.storage()
             .persistent()
             .has(&DataKey::Vote(proposal_id, voter))
+    }
+
+    /// Return the current state of a proposal.
+    ///
+    /// Read-only; does not modify state. Lighter alternative to
+    /// [`get_proposal`](Self::get_proposal) when only the state is needed.
+    ///
+    /// # Parameters
+    /// - `proposal_id` — ID of the proposal to query.
+    ///
+    /// # Returns
+    /// `Ok(`[`ProposalState`]`)` — the proposal's current state.
+    ///
+    /// # Errors
+    /// - [`GovernorError::ProposalNotFound`] — No proposal exists with `proposal_id`.
+    ///
+    /// # Example
+    /// ```text
+    /// let state = client.get_proposal_state(&proposal_id)?;
+    /// assert_eq!(state, ProposalState::Active);
+    /// ```
+    pub fn get_proposal_state(env: Env, proposal_id: u64) -> Result<ProposalState, GovernorError> {
+        let proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(GovernorError::ProposalNotFound)?;
+        Ok(proposal.state)
+    }
+
+    /// Return the current vote tally for a proposal.
+    ///
+    /// Read-only; does not modify state. Returns a breakdown of yes, no, and
+    /// total votes cast so far, regardless of the proposal's current state.
+    ///
+    /// # Parameters
+    /// - `proposal_id` — ID of the proposal to query.
+    ///
+    /// # Returns
+    /// `Ok(`[`VoteTally`]`)` with the current vote counts.
+    ///
+    /// # Errors
+    /// - [`GovernorError::ProposalNotFound`] — No proposal exists with `proposal_id`.
+    ///
+    /// # Example
+    /// ```text
+    /// let tally = client.get_vote_tally(&proposal_id)?;
+    /// println!("yes: {}, no: {}, total: {}", tally.yes_votes, tally.no_votes, tally.total_votes);
+    /// ```
+    pub fn get_vote_tally(env: Env, proposal_id: u64) -> Result<VoteTally, GovernorError> {
+        let proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(GovernorError::ProposalNotFound)?;
+
+        Ok(VoteTally {
+            yes_votes: proposal.votes_for,
+            no_votes: proposal.votes_against,
+            total_votes: proposal.votes_for + proposal.votes_against,
+        })
     }
 
     /// Return the IDs of all proposals that are currently in the active voting period.
@@ -1295,5 +1368,133 @@ mod tests {
                 "pending[{i}] mismatch"
             );
         }
+    }
+
+    #[test]
+    fn test_get_proposal_state_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let result = client.try_get_proposal_state(&99);
+        assert_eq!(result, Err(Ok(GovernorError::ProposalNotFound)));
+    }
+
+    #[test]
+    fn test_get_proposal_state_active() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "State Test"),
+            &String::from_str(&env, "desc"),
+        );
+
+        assert_eq!(client.get_proposal_state(&pid), ProposalState::Active);
+    }
+
+    #[test]
+    fn test_get_proposal_state_passed_and_executed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "State Test"),
+            &String::from_str(&env, "desc"),
+        );
+        client.vote(&voter, &pid, &true, &200);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        client.finalize(&pid);
+        assert_eq!(client.get_proposal_state(&pid), ProposalState::Passed);
+
+        env.ledger().with_mut(|l| l.timestamp = 5000 + 86400 + 1);
+        let executor = Address::generate(&env);
+        client.execute(&executor, &pid);
+        assert_eq!(client.get_proposal_state(&pid), ProposalState::Executed);
+    }
+
+    #[test]
+    fn test_get_proposal_state_failed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "State Test"),
+            &String::from_str(&env, "desc"),
+        );
+        // No votes — quorum not reached
+
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+        client.finalize(&pid);
+        assert_eq!(client.get_proposal_state(&pid), ProposalState::Failed);
+    }
+
+    #[test]
+    fn test_get_vote_tally_no_votes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Tally Test"),
+            &String::from_str(&env, "desc"),
+        );
+
+        let tally = client.get_vote_tally(&pid);
+        assert_eq!(tally.yes_votes, 0);
+        assert_eq!(tally.no_votes, 0);
+        assert_eq!(tally.total_votes, 0);
+    }
+
+    #[test]
+    fn test_get_vote_tally_mixed_votes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let client = setup(&env);
+
+        let proposer = Address::generate(&env);
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Tally Test"),
+            &String::from_str(&env, "desc"),
+        );
+
+        let voter_a = Address::generate(&env);
+        let voter_b = Address::generate(&env);
+        client.vote(&voter_a, &pid, &true, &300);
+        client.vote(&voter_b, &pid, &false, &100);
+
+        let tally = client.get_vote_tally(&pid);
+        assert_eq!(tally.yes_votes, 300);
+        assert_eq!(tally.no_votes, 100);
+        assert_eq!(tally.total_votes, 400);
+    }
+
+    #[test]
+    fn test_get_vote_tally_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup(&env);
+
+        let result = client.try_get_vote_tally(&99);
+        assert_eq!(result, Err(Ok(GovernorError::ProposalNotFound)));
     }
 }

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -458,6 +458,27 @@ impl MultisigContract {
             .unwrap_or(0)
     }
 
+    /// Return the configured timelock delay in seconds.
+    ///
+    /// Read-only; returns `0` if the contract has not been initialized.
+    /// This is the number of seconds that must elapse after a proposal reaches
+    /// the approval threshold before it can be executed.
+    ///
+    /// # Returns
+    /// `u64` — the timelock delay in seconds set at initialization.
+    ///
+    /// # Example
+    /// ```text
+    /// let delay = client.get_timelock_delay();
+    /// println!("Timelock: {} seconds", delay);
+    /// ```
+    pub fn get_timelock_delay(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TimelockDelay)
+            .unwrap_or(0)
+    }
+
     /// Check if an address is one of the multisig owners.
     ///
     /// Read-only; returns `false` if the contract has not been initialized.
@@ -549,6 +570,15 @@ mod tests {
         let o1 = Address::generate(&env);
         let result = client.try_initialize(&vec![&env, o1], &5, &0);
         assert_eq!(result, Err(Ok(MultisigError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_get_timelock_delay() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _, _, _) = setup_2of3(&env);
+        // setup_2of3 initializes with timelock_delay = 3600
+        assert_eq!(client.get_timelock_delay(), 3600);
     }
 
     #[test]

--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -278,6 +278,28 @@ impl ForgeOracle {
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::Admin)
     }
+
+    /// Return the current staleness threshold in seconds.
+    ///
+    /// Read-only; does not modify state. Returns the maximum age of price data
+    /// before [`get_price`](Self::get_price) considers it stale and reverts.
+    ///
+    /// # Returns
+    /// `u64` — the staleness threshold in seconds set at initialization or via
+    /// [`set_staleness_threshold`](Self::set_staleness_threshold).
+    /// Returns `0` if the contract has not been initialized.
+    ///
+    /// # Example
+    /// ```text
+    /// let threshold = client.get_staleness_threshold();
+    /// println!("Prices expire after {} seconds", threshold);
+    /// ```
+    pub fn get_staleness_threshold(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::StalenessThreshold)
+            .unwrap_or(0)
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -857,5 +879,21 @@ mod tests {
 
         let usdt_data = client.get_price(&xlm, &usdt);
         assert_eq!(usdt_data.price, xlm_usdt_price);
+    }
+
+    #[test]
+    fn test_get_staleness_threshold() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, client) = setup(&env);
+
+        // setup initializes with 3600
+        assert_eq!(client.get_staleness_threshold(), 3600);
+
+        // reflects updates via set_staleness_threshold
+        client.set_staleness_threshold(&7200);
+        assert_eq!(client.get_staleness_threshold(), 7200);
+
+        let _ = admin; // suppress unused warning
     }
 }


### PR DESCRIPTION
 feat: add view functions for governance, multisig, and oracle (#149 #150 #151 #152)

Implements four read-only view functions requested across four issues.

Changes

forge-governor
- get_vote_tally(proposal_id) -> VoteTally — returns yes_votes, no_votes, and total_votes for a proposal without requiring off-chain event 
tracking
- get_proposal_state(proposal_id) -> ProposalState — lightweight state check without fetching the full proposal struct

forge-multisig
- get_timelock_delay() -> u64 — returns the configured timelock delay in seconds

forge-oracle
- get_staleness_threshold() -> u64 — returns the current staleness threshold; reflects updates made via set_staleness_threshold()

Tests added
- get_vote_tally: no votes, mixed votes, proposal not found
- get_proposal_state: not found, active, failed, passed → executed
- get_timelock_delay: matches initialization value
- get_staleness_threshold: matches initialization value, reflects update

No breaking changes. All existing tests unaffected.

Closes #149 
Closes #150 
Closes #151 
Closes #152 