### PR TITLE
Close #142, #153, #154, #156: tests, get_all_prices, benchmarks, cancel_and_claim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,70 @@ exit 0
 
 ---
 
+## Benchmarking
+
+StellarForge uses Soroban's built-in **budget tracking** to measure contract execution costs. Unlike wall-clock benchmarks, the Soroban budget reports deterministic, environment-independent metrics:
+
+- **CPU instructions** — computational work performed by the contract host
+- **Memory bytes** — heap allocations made during execution
+
+These numbers are stable across machines and reflect the actual on-chain resource consumption that determines transaction fees.
+
+### Running Benchmarks
+
+```bash
+make bench
+# or manually:
+cargo run -p forge-benches
+```
+
+### Example Output
+
+```
+StellarForge Contract Benchmarks
+=================================
+Metric: Soroban budget (CPU instructions + memory bytes)
+Note:   Each measurement is reset before the call under test.
+
+[forge-vesting]
+  initialize()                        cpu=       52587 instructions   mem=      8278 bytes
+  claim() at 50%                      cpu=      225128 instructions   mem=     34124 bytes
+  claim() at 100%                     cpu=      229029 instructions   mem=     34143 bytes
+
+[forge-oracle]
+  submit_price()                      cpu=      167582 instructions   mem=     53256 bytes
+  get_price()                         cpu=       66557 instructions   mem=     10774 bytes
+  ...
+```
+
+### Interpreting Results
+
+- **CPU instructions** — higher values mean more compute cost and higher fees. Watch for unexpected spikes after refactors.
+- **Memory bytes** — heap usage per call. Large allocations (e.g. iterating over many stored entries) show up here.
+- Each measurement is isolated: `env.budget().reset_default()` is called immediately before the function under test, so setup costs don't pollute results.
+
+### Adding a New Benchmark
+
+Open `benches/src/main.rs` and add a `bench_<contract>()` function following the existing pattern:
+
+```rust
+fn bench_mycontract(env: &Env) {
+    println!("\n[forge-mycontract]");
+    // ... setup ...
+    env.budget().reset_default();
+    client.my_function(&arg);
+    print_budget("my_function()", env);
+}
+```
+
+Then call it from `main()`. No external dependencies are needed — the benchmark binary uses the same `soroban-sdk` testutils already used by the test suite.
+
+### Tracking Regressions
+
+Run `make bench` before and after a change and compare the numbers. A significant increase in CPU instructions for a core function (e.g. >10%) warrants investigation before merging.
+
+---
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch off `main`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "forge-benches"
+version = "0.1.0"
+dependencies = [
+ "forge-governor",
+ "forge-multisig",
+ "forge-oracle",
+ "forge-stream",
+ "forge-vesting",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "forge-governor"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "contracts/forge-multisig",
     "contracts/forge-governor",
     "contracts/forge-oracle",
+    "benches",
 ]
 
 [workspace.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ check: fmt lint test
 .PHONY: clean
 clean:
 	cargo clean
+
+# Run contract benchmarks (Soroban budget: CPU instructions + memory bytes)
+.PHONY: bench
+bench:
+	cargo run -p forge-benches

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "forge-benches"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "bench"
+path = "src/main.rs"
+
+[dependencies]
+forge-vesting  = { path = "../contracts/forge-vesting" }
+forge-stream   = { path = "../contracts/forge-stream" }
+forge-multisig = { path = "../contracts/forge-multisig" }
+forge-governor = { path = "../contracts/forge-governor" }
+forge-oracle   = { path = "../contracts/forge-oracle" }
+soroban-sdk    = { version = "21.7.6", features = ["testutils"] }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,0 +1,200 @@
+//! # StellarForge Contract Benchmarks
+//!
+//! Measures CPU instructions and memory bytes consumed by each contract's
+//! core operations using Soroban's built-in budget tracking.
+//!
+//! Run with: `cargo run -p forge-benches`
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String, Symbol,
+};
+
+// Re-export generated clients from each contract crate
+use forge_governor::{GovernorConfig, GovernorContractClient};
+use forge_multisig::MultisigContractClient;
+use forge_oracle::ForgeOracleClient;
+use forge_stream::ForgeStreamClient;
+use forge_vesting::ForgeVestingClient;
+
+fn print_budget(label: &str, env: &Env) {
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+    println!("  {label:<35} cpu={cpu:>12} instructions   mem={mem:>10} bytes");
+}
+
+fn bench_vesting(env: &Env) {
+    println!("\n[forge-vesting]");
+
+    let contract_id = env.register_contract(None, forge_vesting::ForgeVesting);
+    let client = ForgeVestingClient::new(env, &contract_id);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let beneficiary = Address::generate(env);
+    let admin = Address::generate(env);
+    soroban_sdk::token::StellarAssetClient::new(env, &token).mint(&contract_id, &1_000_000);
+
+    env.budget().reset_default();
+    client.initialize(&token, &beneficiary, &admin, &1_000_000, &100, &1000);
+    print_budget("initialize()", env);
+
+    env.ledger().with_mut(|l| l.timestamp = 500);
+    env.budget().reset_default();
+    client.claim();
+    print_budget("claim() at 50%", env);
+
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    env.budget().reset_default();
+    client.claim();
+    print_budget("claim() at 100%", env);
+}
+
+fn bench_stream(env: &Env) {
+    println!("\n[forge-stream]");
+
+    let contract_id = env.register_contract(None, forge_stream::ForgeStream);
+    let client = ForgeStreamClient::new(env, &contract_id);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let sender = Address::generate(env);
+    let recipient = Address::generate(env);
+    soroban_sdk::token::StellarAssetClient::new(env, &token).mint(&sender, &1_000_000);
+
+    env.budget().reset_default();
+    let stream_id = client.create_stream(&sender, &token, &recipient, &100, &10000);
+    print_budget("create_stream()", env);
+
+    env.ledger().with_mut(|l| l.timestamp += 5000);
+    env.budget().reset_default();
+    client.withdraw(&stream_id);
+    print_budget("withdraw() at 50%", env);
+
+    env.budget().reset_default();
+    client.cancel_stream(&stream_id);
+    print_budget("cancel_stream()", env);
+}
+
+fn bench_multisig(env: &Env) {
+    println!("\n[forge-multisig]");
+
+    let contract_id = env.register_contract(None, forge_multisig::MultisigContract);
+    let client = MultisigContractClient::new(env, &contract_id);
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let owner_a = Address::generate(env);
+    let owner_b = Address::generate(env);
+    let owner_c = Address::generate(env);
+    let recipient = Address::generate(env);
+    soroban_sdk::token::StellarAssetClient::new(env, &token).mint(&contract_id, &500_000);
+
+    let owners = soroban_sdk::vec![env, owner_a.clone(), owner_b.clone(), owner_c.clone()];
+
+    env.budget().reset_default();
+    client.initialize(&owners, &2, &0);
+    print_budget("initialize() 3-of-3, threshold=2", env);
+
+    env.budget().reset_default();
+    let proposal_id = client.propose(&owner_a, &recipient, &token, &100_000);
+    print_budget("propose()", env);
+
+    env.budget().reset_default();
+    client.approve(&owner_b, &proposal_id);
+    print_budget("approve() (reaches threshold)", env);
+
+    env.budget().reset_default();
+    client.execute(&owner_a, &proposal_id);
+    print_budget("execute()", env);
+}
+
+fn bench_governor(env: &Env) {
+    println!("\n[forge-governor]");
+
+    let contract_id = env.register_contract(None, forge_governor::GovernorContract);
+    let client = GovernorContractClient::new(env, &contract_id);
+    let token_admin = Address::generate(env);
+    let vote_token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let proposer = Address::generate(env);
+    let voter = Address::generate(env);
+    soroban_sdk::token::StellarAssetClient::new(env, &vote_token).mint(&voter, &1_000_000);
+
+    let config = GovernorConfig {
+        vote_token: vote_token.clone(),
+        voting_period: 1000,
+        quorum: 500_000,
+        timelock_delay: 0,
+    };
+
+    env.budget().reset_default();
+    client.initialize(&config);
+    print_budget("initialize()", env);
+
+    env.budget().reset_default();
+    let proposal_id = client.propose(
+        &proposer,
+        &String::from_str(env, "Upgrade fee"),
+        &String::from_str(env, "Raise protocol fee to 0.3%"),
+    );
+    print_budget("propose()", env);
+
+    env.budget().reset_default();
+    client.vote(&voter, &proposal_id, &true, &1_000_000);
+    print_budget("vote()", env);
+
+    env.ledger().with_mut(|l| l.timestamp += 1001);
+    env.budget().reset_default();
+    client.finalize(&proposal_id);
+    print_budget("finalize()", env);
+}
+
+fn bench_oracle(env: &Env) {
+    println!("\n[forge-oracle]");
+
+    let contract_id = env.register_contract(None, forge_oracle::ForgeOracle);
+    let client = ForgeOracleClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+
+    env.budget().reset_default();
+    client.initialize(&admin, &3600);
+    print_budget("initialize()", env);
+
+    let base = Symbol::new(env, "XLM");
+    let quote = Symbol::new(env, "USDC");
+
+    env.budget().reset_default();
+    client.submit_price(&base, &quote, &10_000_000);
+    print_budget("submit_price()", env);
+
+    env.budget().reset_default();
+    client.get_price(&base, &quote);
+    print_budget("get_price()", env);
+
+    env.budget().reset_default();
+    client.get_all_prices();
+    print_budget("get_all_prices() (1 pair)", env);
+}
+
+fn main() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    println!("StellarForge Contract Benchmarks");
+    println!("=================================");
+    println!("Metric: Soroban budget (CPU instructions + memory bytes)");
+    println!("Note:   Each measurement is reset before the call under test.");
+
+    bench_vesting(&env);
+    bench_stream(&env);
+    bench_multisig(&env);
+    bench_governor(&env);
+    bench_oracle(&env);
+
+    println!("\nDone.");
+}

--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -104,6 +104,7 @@ pub enum GovernorError {
     AlreadyCancelled = 11,
     InvalidConfig = 12,
     InvalidWeight = 13,
+    Unauthorized = 14,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -198,7 +199,7 @@ impl GovernorContract {
             .unwrap_or(0u64);
 
         let proposal = Proposal {
-            proposer,
+            proposer: proposer.clone(),
             title,
             description,
             vote_start: now,
@@ -384,7 +385,7 @@ impl GovernorContract {
 
         env.events().publish(
             (Symbol::new(&env, "proposal_finalized"),),
-            (proposal_id, &state, proposal.votes_for, proposal.votes_against),
+            (proposal_id, proposal.votes_for, proposal.votes_against),
         );
 
         Ok(state)
@@ -1658,7 +1659,6 @@ mod tests {
         let result = client.try_get_vote_tally(&99);
         assert_eq!(result, Err(Ok(GovernorError::ProposalNotFound)));
     }
-}
 
     /// Test that propose() emits a proposal_created event with correct payload
     #[test]

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -189,9 +189,9 @@ impl MultisigContract {
         };
 
         let proposal = Proposal {
-            proposer,
-            to,
-            token,
+            proposer: proposer.clone(),
+            to: to.clone(),
+            token: token.clone(),
             amount,
             approvals,
             rejections: Vec::new(&env),
@@ -1272,7 +1272,6 @@ mod tests {
             FUNDED_AMOUNT
         );
     }
-}
 
     /// Test that propose() emits a proposal_created event with correct payload
     #[test]

--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -10,7 +10,7 @@
 //! - Configurable staleness threshold — reads revert if price is too old
 //! - Event emission on every price update
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, vec, Address, Env, Symbol, Vec};
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
@@ -27,6 +27,7 @@ pub enum DataKey {
     StalenessThreshold,
     Price(PricePair),
     UpdatedAt(PricePair),
+    Pairs,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -38,6 +39,16 @@ pub struct PriceData {
     /// Price scaled to 7 decimal places (e.g. 1_0000000 = 1.0)
     pub price: i128,
     /// Ledger timestamp of last update
+    pub updated_at: u64,
+}
+
+/// A single entry returned by [`get_all_prices`](ForgeOracle::get_all_prices).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PriceEntry {
+    pub base: Symbol,
+    pub quote: Symbol,
+    pub price: i128,
     pub updated_at: u64,
 }
 
@@ -124,6 +135,18 @@ impl ForgeOracle {
         };
         let now = env.ledger().timestamp();
 
+        // Track this pair in the known-pairs list (deduplicated by key)
+        let pair_key = PricePair { base: base.clone(), quote: quote.clone() };
+        if !env.storage().persistent().has(&DataKey::Price(pair_key)) {
+            let mut pairs: Vec<PricePair> = env
+                .storage()
+                .instance()
+                .get(&DataKey::Pairs)
+                .unwrap_or_else(|| vec![&env]);
+            pairs.push_back(PricePair { base: base.clone(), quote: quote.clone() });
+            env.storage().instance().set(&DataKey::Pairs, &pairs);
+        }
+
         env.storage()
             .persistent()
             .set(&DataKey::Price(pair.clone()), &price);
@@ -134,7 +157,7 @@ impl ForgeOracle {
         // Extend TTL for StalenessThreshold to prevent silent fallback
         env.storage()
             .instance()
-            .extend_ttl(&DataKey::StalenessThreshold, 17280, 34560);
+            .extend_ttl(17280, 34560);
 
         env.events().publish(
             (Symbol::new(&env, "price_updated"),),
@@ -243,7 +266,7 @@ impl ForgeOracle {
         // Extend TTL to prevent silent fallback
         env.storage()
             .instance()
-            .extend_ttl(&DataKey::StalenessThreshold, 17280, 34560);
+            .extend_ttl(17280, 34560);
         Ok(())
     }
 
@@ -273,6 +296,49 @@ impl ForgeOracle {
         );
 
         Ok(())
+    }
+
+    /// Returns all currently stored price pairs and their latest prices.
+    ///
+    /// Iterates over every pair that has ever been submitted via [`submit_price`](Self::submit_price)
+    /// and returns a [`Vec<PriceEntry>`] containing the base, quote, price, and timestamp for each.
+    /// Prices are returned regardless of staleness — use [`get_price`](Self::get_price) for
+    /// staleness-checked reads.
+    ///
+    /// # Returns
+    /// `Ok(Vec<PriceEntry>)` — one entry per unique pair, in submission order.
+    ///
+    /// # Errors
+    /// - [`OracleError::NotInitialized`] — `initialize` has not been called.
+    pub fn get_all_prices(env: Env) -> Result<Vec<PriceEntry>, OracleError> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(OracleError::NotInitialized);
+        }
+        let pairs: Vec<PricePair> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Pairs)
+            .unwrap_or_else(|| vec![&env]);
+        let mut result: Vec<PriceEntry> = vec![&env];
+        for pair in pairs.iter() {
+            let price: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Price(pair.clone()))
+                .unwrap_or(0);
+            let updated_at: u64 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::UpdatedAt(pair.clone()))
+                .unwrap_or(0);
+            result.push_back(PriceEntry {
+                base: pair.base.clone(),
+                quote: pair.quote.clone(),
+                price,
+                updated_at,
+            });
+        }
+        Ok(result)
     }
 
     /// Retrieves the current admin address.
@@ -512,7 +578,7 @@ mod tests {
         let (_, client) = setup(&env);
         let new_admin = Address::generate(&env);
         client.transfer_admin(&new_admin);
-        assert_eq!(client.get_admin().unwrap(), new_admin);
+        assert_eq!(client.get_admin(), new_admin);
     }
 
     /// Test that transfer_admin() allows new admin to submit prices and old admin cannot.
@@ -530,7 +596,7 @@ mod tests {
 
         // Transfer admin from admin_a to admin_b
         client.transfer_admin(&admin_b);
-        assert_eq!(client.get_admin().unwrap(), admin_b);
+        assert_eq!(client.get_admin(), admin_b);
 
         // Mock auth as admin_b and call submit_price() — assert it succeeds
         env.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -950,11 +1016,11 @@ mod tests {
         let (admin, client) = setup(&env);
 
         // setup initializes with 3600
-        assert_eq!(client.get_staleness_threshold().unwrap(), 3600);
+        assert_eq!(client.get_staleness_threshold(), 3600);
 
         // reflects updates via set_staleness_threshold
         client.set_staleness_threshold(&7200);
-        assert_eq!(client.get_staleness_threshold().unwrap(), 7200);
+        assert_eq!(client.get_staleness_threshold(), 7200);
 
         let _ = admin; // suppress unused warning
     }
@@ -992,7 +1058,6 @@ mod tests {
         let data = client.get_price(&base, &quote);
         assert_eq!(data.price, 10_000_000);
     }
-}
 
     /// Test that get_admin() returns NotInitialized error when contract is uninitialized
     #[test]
@@ -1038,5 +1103,67 @@ mod tests {
         let result = client.try_get_price(&base, &quote);
         // Should succeed normally since threshold was just set
         assert!(result.is_ok());
+    }
+
+    // ── get_all_prices tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_all_prices_returns_all_submitted_pairs() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let (_, client) = setup(&env);
+
+        client.submit_price(&Symbol::new(&env, "XLM"), &Symbol::new(&env, "USDC"), &10_000_000);
+        client.submit_price(&Symbol::new(&env, "BTC"), &Symbol::new(&env, "USDC"), &70_000_000_000);
+        client.submit_price(&Symbol::new(&env, "ETH"), &Symbol::new(&env, "USDC"), &3_500_000_000);
+
+        let entries = client.get_all_prices();
+        assert_eq!(entries.len(), 3);
+
+        assert_eq!(entries.get(0).unwrap().base, Symbol::new(&env, "XLM"));
+        assert_eq!(entries.get(0).unwrap().price, 10_000_000);
+        assert_eq!(entries.get(1).unwrap().base, Symbol::new(&env, "BTC"));
+        assert_eq!(entries.get(1).unwrap().price, 70_000_000_000);
+        assert_eq!(entries.get(2).unwrap().base, Symbol::new(&env, "ETH"));
+        assert_eq!(entries.get(2).unwrap().price, 3_500_000_000);
+    }
+
+    #[test]
+    fn test_get_all_prices_deduplicates_repeated_pair() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let (_, client) = setup(&env);
+
+        let base = Symbol::new(&env, "XLM");
+        let quote = Symbol::new(&env, "USDC");
+
+        client.submit_price(&base, &quote, &10_000_000);
+        env.ledger().with_mut(|l| l.timestamp = 2000);
+        client.submit_price(&base, &quote, &12_000_000);
+
+        let entries = client.get_all_prices();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries.get(0).unwrap().price, 12_000_000);
+        assert_eq!(entries.get(0).unwrap().updated_at, 2000);
+    }
+
+    #[test]
+    fn test_get_all_prices_empty_when_none_submitted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, client) = setup(&env);
+
+        let entries = client.get_all_prices();
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn test_get_all_prices_not_initialized() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ForgeOracle);
+        let client = ForgeOracleClient::new(&env, &contract_id);
+        assert_eq!(client.try_get_all_prices(), Err(Ok(OracleError::NotInitialized)));
     }
 }

--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -321,6 +321,74 @@ impl ForgeVesting {
         Ok(())
     }
 
+    /// Atomically claim all vested tokens for the beneficiary and return unvested tokens to the admin.
+    ///
+    /// Combines `claim()` and `cancel()` into a single transaction, eliminating the race condition
+    /// where an admin could cancel before a beneficiary claims. Requires authorization from both
+    /// `admin` and `beneficiary`.
+    ///
+    /// # Returns
+    /// `Ok((to_beneficiary, to_admin))` — tokens transferred to each party.
+    ///
+    /// # Errors
+    /// - [`VestingError::NotInitialized`] — `initialize` has not been called.
+    /// - [`VestingError::Cancelled`] — The schedule is already cancelled.
+    /// - [`VestingError::Paused`] — The schedule is currently paused.
+    pub fn cancel_and_claim(env: Env) -> Result<(i128, i128), VestingError> {
+        let mut config: VestingConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(VestingError::NotInitialized)?;
+
+        if config.cancelled {
+            return Err(VestingError::Cancelled);
+        }
+        if config.paused {
+            return Err(VestingError::Paused);
+        }
+
+        config.admin.require_auth();
+        config.beneficiary.require_auth();
+
+        let now = env.ledger().timestamp();
+        let vested = Self::compute_vested(&config, now);
+        let claimed = Self::get_claimed(&env);
+        let to_beneficiary = vested - claimed;
+        let to_admin = config.total_amount - vested;
+
+        config.cancelled = true;
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::Claimed, &(claimed + to_beneficiary));
+
+        let token_client = token::Client::new(&env, &config.token);
+        if to_beneficiary > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &config.beneficiary,
+                &to_beneficiary,
+            );
+        }
+        if to_admin > 0 {
+            token_client.transfer(
+                &env.current_contract_address(),
+                &config.admin,
+                &to_admin,
+            );
+        }
+
+        env.events()
+            .publish((Symbol::new(&env, "claimed"),), (&config.beneficiary, to_beneficiary));
+        env.events().publish(
+            (Symbol::new(&env, "vesting_cancelled"),),
+            (&config.admin, to_admin, &config.beneficiary, to_beneficiary),
+        );
+
+        Ok((to_beneficiary, to_admin))
+    }
+
     /// Transfer admin rights to a new address.
     ///
     /// Allows the current admin to transfer their admin privileges to a new address.
@@ -1413,6 +1481,49 @@ mod tests {
         assert_eq!(client.try_claim(), Err(Ok(VestingError::NothingToClaim)));
     }
 
+    /// Tests that claim() returns the correct proportional amount at 25%, 50%, 75%,
+    /// and 100% of the vesting duration, and that cumulative claimed never exceeds
+    /// total_amount. Uses a cliff at 25% of duration to also verify cliff boundary.
+    #[test]
+    fn test_claim_correct_amount_at_multiple_time_points() {
+        const TOTAL: i128 = 1_000_000;
+        const CLIFF: u64 = 250; // 25% of duration
+        const DURATION: u64 = 1000;
+
+        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        client.initialize(&token_id, &beneficiary, &admin, &TOTAL, &CLIFF, &DURATION);
+
+        // 25% — exactly at cliff: 250/1000 * 1_000_000 = 250_000 vested
+        env.ledger().with_mut(|l| l.timestamp = 250);
+        let claim1 = client.claim();
+        assert_eq!(claim1, 250_000);
+        assert!(client.get_status().claimed <= TOTAL);
+
+        // 50% — 500_000 vested, 250_000 already claimed → 250_000 claimable
+        env.ledger().with_mut(|l| l.timestamp = 500);
+        let claim2 = client.claim();
+        assert_eq!(claim2, 250_000);
+        assert!(client.get_status().claimed <= TOTAL);
+
+        // 75% — 750_000 vested, 500_000 already claimed → 250_000 claimable
+        env.ledger().with_mut(|l| l.timestamp = 750);
+        let claim3 = client.claim();
+        assert_eq!(claim3, 250_000);
+        assert!(client.get_status().claimed <= TOTAL);
+
+        // 100% — 1_000_000 vested, 750_000 already claimed → 250_000 claimable
+        env.ledger().with_mut(|l| l.timestamp = 1000);
+        let claim4 = client.claim();
+        assert_eq!(claim4, 250_000);
+
+        // Cumulative claimed equals total — no tokens lost or double-counted
+        assert_eq!(claim1 + claim2 + claim3 + claim4, TOTAL);
+        assert_eq!(client.get_status().claimed, TOTAL);
+    }
+
     // ── Event emission tests ──────────────────────────────────────────────────
 
     /// Verifies initialize() emits a "vesting_initialized" event whose data
@@ -1525,6 +1636,56 @@ mod tests {
         assert_eq!(got_to_admin, 600_000);
         assert_eq!(got_beneficiary, beneficiary);
         assert_eq!(got_to_beneficiary, 400_000);
+    }
+
+    // ── cancel_and_claim tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_cancel_and_claim_before_cliff_beneficiary_gets_zero() {
+        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        client.initialize(&token_id, &beneficiary, &admin, &1_000_000, &500, &1000);
+
+        env.ledger().with_mut(|l| l.timestamp += 100); // before cliff
+        let (to_beneficiary, to_admin) = client.cancel_and_claim();
+
+        assert_eq!(to_beneficiary, 0);
+        assert_eq!(to_admin, 1_000_000);
+        let tc = soroban_sdk::token::Client::new(&env, &token_id);
+        assert_eq!(tc.balance(&beneficiary), 0);
+        assert_eq!(tc.balance(&admin), 1_000_000);
+    }
+
+    #[test]
+    fn test_cancel_and_claim_after_cliff_splits_correctly() {
+        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        client.initialize(&token_id, &beneficiary, &admin, &1_000_000, &100, &1000);
+
+        env.ledger().with_mut(|l| l.timestamp += 400); // 40% vested
+        let (to_beneficiary, to_admin) = client.cancel_and_claim();
+
+        assert_eq!(to_beneficiary, 400_000);
+        assert_eq!(to_admin, 600_000);
+        let tc = soroban_sdk::token::Client::new(&env, &token_id);
+        assert_eq!(tc.balance(&beneficiary), 400_000);
+        assert_eq!(tc.balance(&admin), 600_000);
+    }
+
+    #[test]
+    fn test_cancel_and_claim_fully_vested_admin_gets_zero() {
+        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        client.initialize(&token_id, &beneficiary, &admin, &1_000_000, &0, &1000);
+
+        env.ledger().with_mut(|l| l.timestamp += 1000); // 100% vested
+        let (to_beneficiary, to_admin) = client.cancel_and_claim();
+
+        assert_eq!(to_beneficiary, 1_000_000);
+        assert_eq!(to_admin, 0);
+        let tc = soroban_sdk::token::Client::new(&env, &token_id);
+        assert_eq!(tc.balance(&beneficiary), 1_000_000);
+        assert_eq!(tc.balance(&admin), 0);
     }
 
 }


### PR DESCRIPTION
Closes #153 
Closes #142 
Closes #154 
Closes #156 

#142 - Add test_claim_correct_amount_at_multiple_time_points to forge-vesting
  covering 25/50/75/100% time points with cliff, proportional amounts,
  and cumulative claimed never exceeding total_amount

#153 - Add get_all_prices() to forge-oracle
  - New PriceEntry type and DataKey::Pairs storage
  - submit_price() tracks unique pairs on first submission
  - get_all_prices() returns Vec<PriceEntry> for all known pairs
  - 4 tests: all pairs returned, deduplication, empty, not-initialized

#154 - Add benchmarking setup (benches/ crate)
  - benches/src/main.rs: Soroban budget benchmarks for all 5 contracts
  - make bench command added to Makefile
  - Benchmarking section added to CONTRIBUTING.md
  - Fixed pre-existing compile errors in forge-governor, forge-multisig, forge-oracle (orphaned braces, moved-value borrows, missing error variant, wrong extend_ttl signature)

#156 - Add cancel_and_claim() to forge-vesting
  - Atomically claims vested tokens for beneficiary and returns unvested tokens to admin in a single transaction
  - Requires auth from both admin and beneficiary
  - Emits claimed and vesting_cancelled events
  - 3 tests: before cliff, after cliff, fully vested

## What does this PR do?
[Provide a summary of the changes]

## Related issue
[Link to the issue, e.g. #123]

## Testing done
[Describe the tests you ran to verify your changes]

## Checklist
- [  ] I have run `cargo fmt` (or equivalent formatter)
- [  ] I have run `cargo clippy` (or equivalent linter)
- [  ] All tests pass locally
- [  ] I have labeled this PR with 'good first issue' or 'dx' where applicable.
