### PR TITLE
test(forge-stream): verify paused time excluded from streamed after

### DIFF
--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -1796,4 +1796,88 @@ mod tests {
         assert_eq!(token.balance(&sender), 80_000);
         assert_eq!(token.balance(&recipient) + token.balance(&sender), total);
     }
+
+    /// Test that paused time is correctly excluded from streamed amount after resume.
+    ///
+    /// Timeline:
+    ///   t=0    stream created  (rate=100, duration=1000, total=100_000)
+    ///   t=100  pause           (streamed = 100 * 100 = 10_000)
+    ///   t=300  resume          (paused for 200s — those 200s must not count)
+    ///   t=400  check           (effective elapsed = 400 - 200 = 200s → streamed = 20_000)
+    ///   t=500  check           (effective elapsed = 500 - 200 = 300s → streamed = 30_000)
+    ///   t=1200 end of stream   (end_time extended by 200s to 1200; full 100_000 withdrawable)
+    #[test]
+    fn test_paused_time_excluded_from_streamed_after_resume() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+        let sac = StellarAssetClient::new(&env, &token_id);
+
+        let rate: i128 = 100;
+        let duration: u64 = 1000;
+        let total = rate * duration as i128; // 100_000
+
+        sac.mint(&sender, &total);
+
+        // t=0: create stream
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let stream_id = client.create_stream(&sender, &token_id, &recipient, &rate, &duration);
+
+        // t=100: pause — 100s of active time → streamed = 10_000
+        env.ledger().with_mut(|l| l.timestamp = 100);
+        client.pause_stream(&stream_id);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(status.streamed, 10_000, "streamed at pause should be 10_000");
+
+        // t=300: resume — paused for 200s
+        env.ledger().with_mut(|l| l.timestamp = 300);
+        client.resume_stream(&stream_id);
+
+        // t=400: effective elapsed = (400 - 0) - 200 paused = 200s → streamed = 20_000
+        env.ledger().with_mut(|l| l.timestamp = 400);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(
+            status.streamed, 20_000,
+            "at t=400 streamed should be 20_000 (paused 200s excluded), got {}",
+            status.streamed
+        );
+        assert!(
+            status.withdrawn <= status.streamed,
+            "invariant violated: withdrawn {} > streamed {}",
+            status.withdrawn, status.streamed
+        );
+
+        // t=500: effective elapsed = (500 - 0) - 200 paused = 300s → streamed = 30_000
+        env.ledger().with_mut(|l| l.timestamp = 500);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(
+            status.streamed, 30_000,
+            "at t=500 streamed should be 30_000 (paused 200s excluded), got {}",
+            status.streamed
+        );
+
+        // t=1200: end_time was extended by 200s (1000 + 200 = 1200)
+        // Full duration of active time has elapsed → all 100_000 tokens withdrawable
+        env.ledger().with_mut(|l| l.timestamp = 1200);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(
+            status.streamed, total,
+            "at end of stream streamed should equal total {}, got {}",
+            total, status.streamed
+        );
+        assert_eq!(
+            status.withdrawable, total,
+            "full total should be withdrawable at stream end, got {}",
+            status.withdrawable
+        );
+        assert!(status.is_finished, "stream should be finished at t=1200");
+    }
 }


### PR DESCRIPTION
Closes #201 

Summary: Adds test_paused_time_excluded_from_streamed_after_resume — creates a 100/sec × 1000s stream, pauses at t=100, resumes at t=300 (200s paused), then asserts streamed == 20_000 at t=400 and streamed == 30_000 at t=500 (not 40_000/50_000). Also verifies the full 100_000 is withdrawable at t=1200 (end_time extended by the 200s pause), and that withdrawn <= streamed holds throughout.