### PR TITLE
feat(forge-multisig): add get_timelock_delay() view function (#280)

### DIFF
--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -750,6 +750,17 @@ mod tests {
     }
 
     #[test]
+    fn test_get_timelock_delay_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, MultisigContract);
+        let client = MultisigContractClient::new(&env, &contract_id);
+        let o1 = Address::generate(&env);
+        client.initialize(&vec![&env, o1], &1, &0);
+        assert_eq!(client.get_timelock_delay(), 0);
+    }
+
+    #[test]
     fn test_initialize_with_duplicate_owners() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
Closes #280

## What changed
-  was already present in the contract implementation (reading from DataKey::TimelockDelay, returning 0 if uninitialized — consistent with get_threshold() behaviour) and had one test covering the non-zero case.
- Added the missing test  that initializes a 1-of-1 multisig with timelock_delay = 0 and asserts the view function returns 0, satisfying the issue requirement for a zero-delay test case.

## Tests
- test_get_timelock_delay        — verifies returned value matches the
                                   3600 s delay passed to initialize()
- test_get_timelock_delay_zero   — verifies returned value is 0 for a
                                   zero-delay multisig (new)

