### PR TITLE
feat(forge-vesting): add change_beneficiary() with cancelled guard 

### DIFF
--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -462,6 +462,7 @@ impl ForgeVesting {
     ///
     /// # Errors
     /// - [`VestingError::NotInitialized`] — `initialize` has not been called.
+    /// - [`VestingError::Cancelled`] — The vesting schedule has been cancelled.
     /// - [`VestingError::SameBeneficiary`] — `new_beneficiary` is the same as the current beneficiary.
     ///
     /// # Example
@@ -477,6 +478,10 @@ impl ForgeVesting {
             .ok_or(VestingError::NotInitialized)?;
 
         config.beneficiary.require_auth();
+
+        if config.cancelled {
+            return Err(VestingError::Cancelled);
+        }
 
         if config.beneficiary == new_beneficiary {
             return Err(VestingError::SameBeneficiary);
@@ -1196,6 +1201,17 @@ mod tests {
         let new_beneficiary = Address::generate(&env);
         let result = client.try_change_beneficiary(&new_beneficiary);
         assert_eq!(result, Err(Ok(VestingError::NotInitialized)));
+    }
+
+    #[test]
+    fn test_change_beneficiary_cancelled_fails() {
+        let (env, contract_id, token, beneficiary, admin) = setup();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        client.initialize(&token, &beneficiary, &admin, &1_000_000, &100, &1000);
+        client.cancel();
+        let new_beneficiary = Address::generate(&env);
+        let result = client.try_change_beneficiary(&new_beneficiary);
+        assert_eq!(result, Err(Ok(VestingError::Cancelled)));
     }
 
     /// Verifies the fully vested state end-to-end:


### PR DESCRIPTION


Closes #279

## What changed

### Implementation
- change_beneficiary() was already present with auth, SameBeneficiary check, beneficiary_changed event emission, and doc comment.
- Added missing Cancelled guard: returns VestingError::Cancelled if the vesting schedule has been cancelled, consistent with other mutating functions (cancel_and_claim, claim, etc.).
- Updated doc comment to document the new Cancelled error case.

### Tests
All previously required tests were already present:
  - test_change_beneficiary_success
  - test_change_beneficiary_by_non_beneficiary_fails
  - test_change_beneficiary_to_same_beneficiary_fails
  - test_change_beneficiary_preserves_claimed_amount (verifies subsequent claim() transfers to new beneficiary)
  - test_change_beneficiary_not_initialized_fails

Added the one missing test from the issue checklist:
  - test_change_beneficiary_cancelled_fails — cancels the schedule then asserts change_beneficiary returns VestingError::Cancelled
