### PR TITLE
refactor(forge-vesting): deprecate get_config() in favour of get_vest…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Deploy tokens on a vesting schedule with an optional cliff period. Perfect for t
 * **Key Function:** `initialize(token, beneficiary, admin, total_amount, cliff_seconds, duration_seconds)`
 * **Action:** `claim()` withdraws all currently unlocked tokens.
 * **Security:** `cancel()` allows the admin to return unvested tokens if a contributor leaves.
+* **Read functions:** Three query functions serve different audiences:
+  * `get_vesting_schedule()` — public-facing; returns token, beneficiary, amounts, and timing. No admin address or cancellation state.
+  * `get_status()` — public-facing; returns claimable amount, vested amount, cliff status, and pause state.
+  * `get_config()` — admin tooling only; returns the full internal config including admin address and cancellation flag. Prefer the two functions above for UI integrations.
 
 ### forge-stream
 Pay-per-second token streams. Ideal for payroll, subscriptions, or real-time contractor payments.

--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -562,17 +562,21 @@ impl ForgeVesting {
     /// amounts, timing parameters, and cancellation status. Read-only; does not
     /// modify state.
     ///
+    /// # Deprecation Notice
+    ///
+    /// **Prefer [`get_vesting_schedule`] and [`get_status`] for public-facing reads.**
+    /// `get_config` exposes the admin address and internal cancellation flag, which
+    /// may be a privacy concern in some deployments. Use the alternatives instead:
+    /// - [`get_vesting_schedule`] — token, beneficiary, amounts, and timing (no admin)
+    /// - [`get_status`] — claimable amount, vested amount, cliff status, and pause state
+    ///
+    /// `get_config` is retained for admin tooling and backward compatibility.
+    ///
     /// # Returns
     /// `Ok(`[`VestingConfig`]`)` with the stored configuration.
     ///
     /// # Errors
     /// - [`VestingError::NotInitialized`] — `initialize` has not been called.
-    ///
-    /// # Example
-    /// ```rust,ignore
-    /// let config = client.get_config();
-    /// println!("Beneficiary: {:?}", config.beneficiary);
-    /// ```rust,ignore
     pub fn get_config(env: Env) -> Result<VestingConfig, VestingError> {
         env.storage()
             .instance()
@@ -891,6 +895,32 @@ mod tests {
         let client = ForgeVestingClient::new(&env, &contract_id);
         let result = client.try_get_vesting_schedule();
         assert_eq!(result, Err(Ok(VestingError::NotInitialized)));
+    }
+
+    #[test]
+    fn test_schedule_and_status_provide_full_ui_info_without_get_config() {
+        // get_vesting_schedule() + get_status() together expose everything a UI
+        // needs: token, beneficiary, amounts, timing, claimable — without
+        // leaking the admin address or internal cancellation flag.
+        let (env, contract_id, token, beneficiary, admin) = setup();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        client.initialize(&token, &beneficiary, &admin, &1_000_000, &100, &1000);
+
+        // Advance past cliff
+        env.ledger().with_mut(|l| l.timestamp += 500);
+
+        let schedule = client.get_vesting_schedule();
+        assert_eq!(schedule.token, token);
+        assert_eq!(schedule.beneficiary, beneficiary);
+        assert_eq!(schedule.total_amount, 1_000_000);
+        assert_eq!(schedule.cliff_seconds, 100);
+        assert_eq!(schedule.duration_seconds, 1000);
+
+        let status = client.get_status();
+        assert!(status.cliff_reached);
+        assert!(status.claimable > 0);
+        assert_eq!(status.claimed, 0);
+        assert!(!status.fully_vested);
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

`get_config()` returns the full `VestingConfig` including the admin address
and internal `cancelled` flag. Exposing the admin address publicly is a
privacy concern, and having three read functions with no guidance creates
confusion about which one integrators should use.

The contract already has cleaner alternatives — `get_vesting_schedule()` for
schedule parameters and `get_status()` for live claimable state. This PR
adds a deprecation notice to `get_config()` pointing to those, documents
the distinction in the README, and adds a test proving the two preferred
functions together cover all UI-facing data needs.

No behaviour changes. `get_config()` is retained for admin tooling and
backward compatibility.

## Related issue

## Testing done

Added `test_schedule_and_status_provide_full_ui_info_without_get_config`:
initializes a vesting schedule, advances past the cliff, and asserts that
`get_vesting_schedule()` + `get_status()` together expose token, beneficiary,
amounts, timing, cliff status, and claimable amount — without needing
`get_config()`.

## Checklist
- [ ] I have run `cargo fmt` (or equivalent formatter)
- [ ] I have run `cargo clippy` (or equivalent linter)
- [ ] All tests pass locally
- [ ] I have labeled this PR with 'good first issue' or 'dx' where applicable.

Closes #244
