### PR TITLE
Add post-withdraw get_claimable regression test for forge-stream

### DIFF
--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -1348,6 +1348,32 @@ mod tests {
     }
 
     #[test]
+    fn test_get_claimable_resets_after_withdraw_and_only_counts_new_accrual() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = setup_token(&env, &sender, 100 * 1000);
+
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+        env.ledger().with_mut(|l| l.timestamp += 100);
+
+        assert_eq!(client.get_claimable(&stream_id), 10_000);
+
+        let withdrawn = client.withdraw(&stream_id);
+        assert_eq!(withdrawn, 10_000);
+        assert_eq!(client.get_claimable(&stream_id), 0);
+        assert_eq!(client.get_stream_status(&stream_id).withdrawable, 0);
+
+        env.ledger().with_mut(|l| l.timestamp += 50);
+
+        assert_eq!(client.get_claimable(&stream_id), 5_000);
+        assert_eq!(client.get_stream_status(&stream_id).withdrawable, 5_000);
+    }
+
+    #[test]
     fn test_get_claimable_cancelled_stream_returns_zero() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
## Summary
- add a regression test covering the common UI polling flow around `get_claimable()`
- verify claimable is zero immediately after `withdraw()` with no time passing
- verify only newly accrued tokens are claimable after additional time elapses

Closes #314