### PR TITLE
Overflow protection in compute_streamed() and create_stream()

### DIFF
--- a/contracts/forge-stream/README.md
+++ b/contracts/forge-stream/README.md
@@ -7,16 +7,17 @@
 contract instance TTL; use **instance** for small, frequently-accessed
 scalars that are always read together with the contract instance.
 
-| `DataKey` variant | Storage type | Rationale |
-| :--- | :--- | :--- |
-| `Stream(u64)` | `persistent` | Stream data must outlive the instance TTL while tokens remain unclaimed |
-| `NextId` | `instance` | Small scalar always read on `create_stream`; co-located with instance for efficiency |
-| `ActiveStreamsCount` | `instance` | Updated on every create/cancel/finish; always accessed with other instance data |
-| `SenderStreams(Address)` | `persistent` | Grows with each stream; must survive beyond instance TTL for historical lookups |
-| `RecipientStreams(Address)` | `persistent` | Same rationale as `SenderStreams` |
+| `DataKey` variant           | Storage type | Rationale                                                                            |
+| :-------------------------- | :----------- | :----------------------------------------------------------------------------------- |
+| `Stream(u64)`               | `persistent` | Stream data must outlive the instance TTL while tokens remain unclaimed              |
+| `NextId`                    | `instance`   | Small scalar always read on `create_stream`; co-located with instance for efficiency |
+| `ActiveStreamsCount`        | `instance`   | Updated on every create/cancel/finish; always accessed with other instance data      |
+| `SenderStreams(Address)`    | `persistent` | Grows with each stream; must survive beyond instance TTL for historical lookups      |
+| `RecipientStreams(Address)` | `persistent` | Same rationale as `SenderStreams`                                                    |
 
 When adding a new `DataKey` variant, choose the storage type using this
 checklist:
+
 - Does the data need to survive after the contract instance TTL expires? → **persistent**
 - Is it a small scalar read on almost every call? → **instance**
 - Is it keyed per-user or per-stream (unbounded growth)? → **persistent**

--- a/contracts/forge-stream/README.md
+++ b/contracts/forge-stream/README.md
@@ -29,34 +29,36 @@ checklist:
 
 ### Function Resource Estimates
 
-| Function | CPU Instructions | Memory (bytes) | Ledger Reads | Ledger Writes | Notes |
-| :--- | :---: | :---: | :---: | :---: | :--- |
-| `create_stream` | ~85,000 | ~3,500 | 2 | 3 | Most expensive - validates inputs, creates stream |
-| `withdraw` | ~65,000 | ~2,500 | 3 | 2 | Calculates accrued amount, transfers tokens |
-| `cancel_stream` | ~70,000 | ~3,000 | 3 | 2 | Calculates final amounts, refunds/pays out |
-| `pause_stream` | ~45,000 | ~2,000 | 2 | 1 | Marks stream as paused |
-| `resume_stream` | ~50,000 | ~2,200 | 2 | 1 | Adjusts for paused time, resumes stream |
-| `get_stream` | ~20,000 | ~1,500 | 2 | 0 | Read-only query |
-| `get_withdrawable` | ~25,000 | ~1,800 | 2 | 0 | Calculates current accrued amount |
+| Function           | CPU Instructions | Memory (bytes) | Ledger Reads | Ledger Writes | Notes                                             |
+| :----------------- | :--------------: | :------------: | :----------: | :-----------: | :------------------------------------------------ |
+| `create_stream`    |     ~85,000      |     ~3,500     |      2       |       3       | Most expensive - validates inputs, creates stream |
+| `withdraw`         |     ~65,000      |     ~2,500     |      3       |       2       | Calculates accrued amount, transfers tokens       |
+| `cancel_stream`    |     ~70,000      |     ~3,000     |      3       |       2       | Calculates final amounts, refunds/pays out        |
+| `pause_stream`     |     ~45,000      |     ~2,000     |      2       |       1       | Marks stream as paused                            |
+| `resume_stream`    |     ~50,000      |     ~2,200     |      2       |       1       | Adjusts for paused time, resumes stream           |
+| `get_stream`       |     ~20,000      |     ~1,500     |      2       |       0       | Read-only query                                   |
+| `get_withdrawable` |     ~25,000      |     ~1,800     |      2       |       0       | Calculates current accrued amount                 |
 
 ### Most Expensive Functions
 
 1. **`create_stream`** (~85,000 CPU instructions)
-   - Why: Validates sender/recipient, encodes stream parameters, creates multiple storage entries
-   - Optimization tip: Reuse stream configurations for recurring payments
+    - Why: Validates sender/recipient, encodes stream parameters, creates multiple storage entries
+    - Optimization tip: Reuse stream configurations for recurring payments
 
 2. **`cancel_stream`** (~70,000 CPU instructions)
-   - Why: Calculates final amounts, handles partial refunds, updates multiple storage entries
-   - Optimization tip: Use pause/resume instead of cancel/recreate for temporary stops
+    - Why: Calculates final amounts, handles partial refunds, updates multiple storage entries
+    - Optimization tip: Use pause/resume instead of cancel/recreate for temporary stops
 
 ### Cost Estimation
 
 Soroban charges fees based on:
+
 - **CPU Instructions:** ~0.0001 XLM per 10,000 instructions
 - **Memory:** ~0.00001 XLM per byte
 - **Ledger Entries:** ~0.001 XLM per read/write
 
 **Example:** Creating a stream costs approximately:
+
 - CPU: 85,000 instructions × 0.0001 XLM / 10,000 = 0.00085 XLM
 - Memory: 3,500 bytes × 0.00001 XLM = 0.035 XLM
 - Ledger: 5 operations × 0.001 XLM = 0.005 XLM
@@ -67,3 +69,10 @@ Soroban charges fees based on:
 ## Known Limitations
 
 - No mid-stream rate changes
+
+## Overflow Protection
+
+`forge-stream` guards against i128 multiplication overflow in two places:
+
+- **`create_stream()`** — `rate_per_second * duration_seconds` uses `checked_mul` and returns `InvalidConfig` if the product would exceed `i128::MAX`. This prevents a stream from being created with a total that cannot be represented.
+- **`compute_streamed()`** — `rate_per_second * effective_elapsed` uses `checked_mul` and falls back to `total` (the stream's maximum payout) if overflow would occur. The result is also capped at `total`, so callers always receive a value in `[0, total]` regardless of elapsed time or rate magnitude.

--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -865,7 +865,8 @@ impl ForgeStream {
         // Overflow protection: if rate * elapsed would exceed i128::MAX, cap at
         // total (rate * duration) which is the maximum tokens this stream can ever
         // release. This prevents silent truncation on extreme rate/elapsed combos.
-        let total = stream.rate_per_second * (stream.end_time - stream.start_time) as i128;
+        let duration = stream.end_time.saturating_sub(stream.start_time);
+        let total = stream.rate_per_second * duration as i128;
         stream
             .rate_per_second
             .checked_mul(effective_elapsed as i128)
@@ -1555,104 +1556,6 @@ mod tests {
         let status_after = client.get_stream_status(&stream_id);
         assert_eq!(status_after.withdrawn, 10_000);
         assert_eq!(status_after.withdrawable, 0);
-    }
-
-    /// pause_stream() must emit a "stream_paused" event whose data contains the
-    /// correct stream_id.
-    #[test]
-    fn test_pause_stream_emits_event() {
-        use soroban_sdk::testutils::Events;
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, ForgeStream);
-        let client = ForgeStreamClient::new(&env, &contract_id);
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token = setup_token(&env, &sender, 100 * 1000);
-
-        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
-        env.ledger().with_mut(|l| l.timestamp += 100);
-
-        client.pause_stream(&stream_id);
-
-        let events = env.events().all();
-        let found = events.iter().any(|(_, topics, data)| {
-            topics
-                .get(0)
-                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
-                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_paused"))
-                .unwrap_or(false)
-                && <u64>::try_from_val(&env, &data)
-                    .map(|id| id == stream_id)
-                    .unwrap_or(false)
-        });
-        assert!(found, "Expected stream_paused event with stream_id={stream_id} not found");
-    }
-
-    /// resume_stream() must emit a "stream_resumed" event whose data contains
-    /// the correct stream_id.
-    #[test]
-    fn test_resume_stream_emits_event() {
-        use soroban_sdk::testutils::Events;
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, ForgeStream);
-        let client = ForgeStreamClient::new(&env, &contract_id);
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token = setup_token(&env, &sender, 100 * 1000);
-
-        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
-        env.ledger().with_mut(|l| l.timestamp += 100);
-        client.pause_stream(&stream_id);
-        env.ledger().with_mut(|l| l.timestamp += 50);
-
-        client.resume_stream(&stream_id);
-
-        let events = env.events().all();
-        let found = events.iter().any(|(_, topics, data)| {
-            topics
-                .get(0)
-                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
-                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_resumed"))
-                .unwrap_or(false)
-                && <u64>::try_from_val(&env, &data)
-                    .map(|id| id == stream_id)
-                    .unwrap_or(false)
-        });
-        assert!(found, "Expected stream_resumed event with stream_id={stream_id} not found");
-    }
-
-    /// A failed pause_stream() (already paused) must not emit a stream_paused
-    /// event — the event list should contain only the first successful pause.
-    #[test]
-    fn test_no_pause_event_on_failed_pause() {
-        use soroban_sdk::testutils::Events;
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, ForgeStream);
-        let client = ForgeStreamClient::new(&env, &contract_id);
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token = setup_token(&env, &sender, 100 * 1000);
-
-        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
-        client.pause_stream(&stream_id); // succeeds — emits one event
-
-        // Second pause must fail
-        let result = client.try_pause_stream(&stream_id);
-        assert_eq!(result, Err(Ok(StreamError::InvalidConfig)));
-
-        // Only one stream_paused event should exist (from the first call)
-        let events = env.events().all();
-        let pause_event_count = events.iter().filter(|(_, topics, _)| {
-            topics
-                .get(0)
-                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
-                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_paused"))
-                .unwrap_or(false)
-        }).count();
-        assert_eq!(pause_event_count, 1, "Expected exactly 1 stream_paused event, got {pause_event_count}");
     }
 
     #[test]

--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -152,7 +152,11 @@ impl ForgeStream {
             .unwrap_or(0_u64);
 
         let now = env.ledger().timestamp();
-        let total = rate_per_second * duration_seconds as i128;
+        // Guard against overflow: rate * duration must not exceed i128::MAX.
+        // If it would, reject the stream rather than silently truncate.
+        let total = rate_per_second
+            .checked_mul(duration_seconds as i128)
+            .ok_or(StreamError::InvalidConfig)?;
 
         // Pull total tokens from sender into contract
         let token_client = token::Client::new(&env, &token);
@@ -858,7 +862,15 @@ impl ForgeStream {
             }
         }
         let effective_elapsed = raw_elapsed.saturating_sub(paused_time);
-        stream.rate_per_second * effective_elapsed as i128
+        // Overflow protection: if rate * elapsed would exceed i128::MAX, cap at
+        // total (rate * duration) which is the maximum tokens this stream can ever
+        // release. This prevents silent truncation on extreme rate/elapsed combos.
+        let total = stream.rate_per_second * (stream.end_time - stream.start_time) as i128;
+        stream
+            .rate_per_second
+            .checked_mul(effective_elapsed as i128)
+            .unwrap_or(total)
+            .min(total)
     }
 
     fn active_streams_count(env: &Env) -> u64 {
@@ -1238,6 +1250,46 @@ mod tests {
         assert_eq!(status.streamed + status.remaining, total);
 
         env.ledger().with_mut(|l| l.timestamp += 500);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(status.streamed, total);
+        assert_eq!(status.remaining, 0);
+        assert_eq!(status.streamed + status.remaining, total);
+    }
+
+    /// rate = i128::MAX / 2, duration = 3: intermediate multiplication would
+    /// overflow without checked_mul. Verifies compute_streamed() caps at total
+    /// and never panics or returns a corrupted value.
+    #[test]
+    fn test_high_rate_overflow_protection() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let duration = 3u64;
+        let rate = i128::MAX / 2; // rate * 2 fits in i128, but rate * 3 overflows
+        let total = rate * duration as i128; // safe: (MAX/2) * 3 < MAX
+        let token = setup_token(&env, &sender, total);
+
+        let stream_id = client.create_stream(&sender, &token, &recipient, &rate, &duration);
+
+        // At t=1: rate * 1 is fine
+        env.ledger().with_mut(|l| l.timestamp += 1);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(status.streamed, rate);
+        assert!(status.streamed <= total);
+
+        // At t=2: rate * 2 is fine
+        env.ledger().with_mut(|l| l.timestamp += 1);
+        let status = client.get_stream_status(&stream_id);
+        assert_eq!(status.streamed, rate * 2);
+        assert!(status.streamed <= total);
+
+        // At t=3 (end): rate * 3 would overflow i128 without checked_mul;
+        // result must be capped at total, not panic or wrap.
+        env.ledger().with_mut(|l| l.timestamp += 1);
         let status = client.get_stream_status(&stream_id);
         assert_eq!(status.streamed, total);
         assert_eq!(status.remaining, 0);

--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -1557,6 +1557,104 @@ mod tests {
         assert_eq!(status_after.withdrawable, 0);
     }
 
+    /// pause_stream() must emit a "stream_paused" event whose data contains the
+    /// correct stream_id.
+    #[test]
+    fn test_pause_stream_emits_event() {
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = setup_token(&env, &sender, 100 * 1000);
+
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+        env.ledger().with_mut(|l| l.timestamp += 100);
+
+        client.pause_stream(&stream_id);
+
+        let events = env.events().all();
+        let found = events.iter().any(|(_, topics, data)| {
+            topics
+                .get(0)
+                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_paused"))
+                .unwrap_or(false)
+                && <u64>::try_from_val(&env, &data)
+                    .map(|id| id == stream_id)
+                    .unwrap_or(false)
+        });
+        assert!(found, "Expected stream_paused event with stream_id={stream_id} not found");
+    }
+
+    /// resume_stream() must emit a "stream_resumed" event whose data contains
+    /// the correct stream_id.
+    #[test]
+    fn test_resume_stream_emits_event() {
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = setup_token(&env, &sender, 100 * 1000);
+
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+        env.ledger().with_mut(|l| l.timestamp += 100);
+        client.pause_stream(&stream_id);
+        env.ledger().with_mut(|l| l.timestamp += 50);
+
+        client.resume_stream(&stream_id);
+
+        let events = env.events().all();
+        let found = events.iter().any(|(_, topics, data)| {
+            topics
+                .get(0)
+                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_resumed"))
+                .unwrap_or(false)
+                && <u64>::try_from_val(&env, &data)
+                    .map(|id| id == stream_id)
+                    .unwrap_or(false)
+        });
+        assert!(found, "Expected stream_resumed event with stream_id={stream_id} not found");
+    }
+
+    /// A failed pause_stream() (already paused) must not emit a stream_paused
+    /// event — the event list should contain only the first successful pause.
+    #[test]
+    fn test_no_pause_event_on_failed_pause() {
+        use soroban_sdk::testutils::Events;
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = setup_token(&env, &sender, 100 * 1000);
+
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+        client.pause_stream(&stream_id); // succeeds — emits one event
+
+        // Second pause must fail
+        let result = client.try_pause_stream(&stream_id);
+        assert_eq!(result, Err(Ok(StreamError::InvalidConfig)));
+
+        // Only one stream_paused event should exist (from the first call)
+        let events = env.events().all();
+        let pause_event_count = events.iter().filter(|(_, topics, _)| {
+            topics
+                .get(0)
+                .and_then(|t| soroban_sdk::Symbol::try_from_val(&env, &t).ok())
+                .map(|s| s == soroban_sdk::Symbol::new(&env, "stream_paused"))
+                .unwrap_or(false)
+        }).count();
+        assert_eq!(pause_event_count, 1, "Expected exactly 1 stream_paused event, got {pause_event_count}");
+    }
+
     #[test]
     fn test_pause_already_paused() {
         let env = Env::default();


### PR DESCRIPTION
## Summary

Fixes a silent i128 overflow bug in `forge-stream` where multiplying `rate_per_second` by `effective_elapsed as i128` in `compute_streamed()` could exceed `i128::MAX` for large rate/elapsed combinations, producing corrupted streamed amounts without panicking.

this pr Closes #303 

## Changes

### `contracts/forge-stream/src/lib.rs`

- **`create_stream()`** — replaced `rate_per_second * duration_seconds as i128` with `checked_mul(...).ok_or(StreamError::InvalidConfig)?`. Streams whose total would overflow i128 are rejected at creation.

- **`compute_streamed()`** — replaced `rate_per_second * effective_elapsed as i128` with `checked_mul(...).unwrap_or(total).min(total)`. On overflow, the result is capped at `total` (the stream's maximum payout), ensuring the return value is always in `[0, total]`.

- **`test_high_rate_overflow_protection`** — new test using `rate = i128::MAX / 2` and `duration = 3`. At `t=3`, `rate * 3` overflows i128 without the fix. Verifies `streamed == total`, `remaining == 0`, and no panic.

### `contracts/forge-stream/README.md`

- Added **Overflow Protection** section documenting both guards.

## Testing

```bash
cargo test -p forge-stream
