### PR TITLE
spec: add vesting configurable start time

### DIFF
--- a/.kiro/specs/vesting-configurable-start-time/.config.kiro
+++ b/.kiro/specs/vesting-configurable-start-time/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/vesting-configurable-start-time/design.md
+++ b/.kiro/specs/vesting-configurable-start-time/design.md
@@ -1,0 +1,151 @@
+# Design Document: Vesting Configurable Start Time
+
+## Overview
+
+This change adds an optional `start_time: Option<u64>` parameter to `ForgeVesting::initialize()`. When `None` is supplied the contract defaults to `env.ledger().timestamp()`, preserving existing behaviour exactly. When `Some(t)` is supplied the contract validates that `t >= env.ledger().timestamp()` and stores `t` as the vesting start. All elapsed-time calculations in `compute_vested` already use `config.start_time`, so no changes are needed there beyond the new validation at initialization.
+
+## Architecture
+
+The change is entirely contained within the `forge-vesting` crate. No new storage keys, no new contract interfaces, and no cross-contract interactions are introduced.
+
+```mermaid
+flowchart TD
+    A[initialize called] --> B{start_time param}
+    B -- None --> C[use env.ledger().timestamp()]
+    B -- Some t --> D{t >= now?}
+    D -- yes --> E[use t]
+    D -- no --> F[return InvalidConfig]
+    C --> G[store VestingConfig]
+    E --> G
+    G --> H[emit vesting_initialized event]
+```
+
+## Components and Interfaces
+
+### `initialize()` signature change
+
+```rust
+pub fn initialize(
+    env: Env,
+    token: Address,
+    beneficiary: Address,
+    admin: Address,
+    total_amount: i128,
+    cliff_seconds: u64,
+    duration_seconds: u64,
+    start_time: Option<u64>,          // NEW
+) -> Result<(), VestingError>
+```
+
+The resolution logic inserted before the `VestingConfig` construction:
+
+```rust
+let resolved_start = match start_time {
+    None => env.ledger().timestamp(),
+    Some(t) => {
+        if t < env.ledger().timestamp() {
+            return Err(VestingError::InvalidConfig);
+        }
+        t
+    }
+};
+```
+
+`VestingConfig { start_time: resolved_start, .. }` replaces the previous inline `env.ledger().timestamp()` call.
+
+### `VestingConfig` — no structural change
+
+`VestingConfig.start_time` already exists as a `u64` field. No migration or schema change is required.
+
+### `compute_vested` — no change
+
+The function already reads `config.start_time` for all elapsed-time arithmetic. It will automatically use the new resolved value without modification.
+
+## Data Models
+
+No new fields or storage keys. The only change is how `VestingConfig.start_time` is populated during `initialize()`.
+
+| Field | Type | Change |
+|---|---|---|
+| `VestingConfig.start_time` | `u64` | Value now comes from caller-supplied `Option<u64>` or ledger timestamp |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: None start_time defaults to ledger timestamp
+
+*For any* ledger timestamp `now`, calling `initialize()` with `start_time = None` and then reading `get_config().start_time` should equal `now`.
+
+**Validates: Requirements 1.2, 2.2**
+
+### Property 2: Future start_time is stored verbatim
+
+*For any* timestamp `t >= env.ledger().timestamp()`, calling `initialize()` with `start_time = Some(t)` and then reading `get_config().start_time` should equal `t`.
+
+**Validates: Requirements 1.3, 2.1, 2.2**
+
+### Property 3: Past start_time is rejected
+
+*For any* timestamp `t < env.ledger().timestamp()`, calling `initialize()` with `start_time = Some(t)` should return `VestingError::InvalidConfig`.
+
+**Validates: Requirements 1.4**
+
+### Property 4: get_vesting_schedule reflects resolved start_time
+
+*For any* valid `start_time` (None or Some(t >= now)), calling `get_vesting_schedule()` after initialization should return a `VestingSchedule` whose `start_time` equals the resolved value stored in `VestingConfig`.
+
+**Validates: Requirements 2.3**
+
+### Property 5: Vesting amount correctness relative to configured start_time
+
+*For any* vesting config with a future `start_time` and *for any* ledger timestamp `now`:
+- If `now < start_time + cliff_seconds`, `claim()` returns `CliffNotReached` (or `compute_vested` returns 0).
+- If `now >= start_time + cliff_seconds` and `now < start_time + duration_seconds`, the vested amount equals `(total_amount * elapsed) / duration_seconds` where `elapsed = now - start_time`.
+- If `now >= start_time + duration_seconds`, the vested amount equals `total_amount`.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+
+## Error Handling
+
+| Condition | Error |
+|---|---|
+| `start_time = Some(t)` where `t < env.ledger().timestamp()` | `VestingError::InvalidConfig` |
+
+All existing `InvalidConfig` conditions (`total_amount <= 0`, `duration_seconds == 0`, `cliff_seconds > duration_seconds`) are unchanged and checked in the same guard.
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+Both unit tests and property-based tests are used. Unit tests cover specific examples and edge cases; property tests verify universal correctness across generated inputs.
+
+### Property-Based Testing
+
+The Rust property-based testing library **`proptest`** is used (added as a `[dev-dependency]`). Each property test runs a minimum of 100 iterations.
+
+Each property test is annotated with a comment referencing its design property:
+```
+// Feature: vesting-configurable-start-time, Property N: <property text>
+```
+
+**Property test mapping:**
+
+| Property | Test description |
+|---|---|
+| Property 1 | Generate random ledger timestamps; initialize with `None`; assert `config.start_time == now` |
+| Property 2 | Generate random `t >= now`; initialize with `Some(t)`; assert `config.start_time == t` |
+| Property 3 | Generate random `t < now`; initialize with `Some(t)`; assert `Err(InvalidConfig)` |
+| Property 4 | Generate valid configs; assert `get_vesting_schedule().start_time == get_config().start_time` |
+| Property 5 | Generate valid configs with future start; generate `now` across full timeline; assert vested amount matches formula |
+
+### Unit Tests
+
+Unit tests cover:
+- `initialize()` with `start_time = None` (present-time default, backward-compat)
+- `initialize()` with `start_time = Some(future)` (accepted)
+- `initialize()` with `start_time = Some(past)` (rejected with `InvalidConfig`)
+- `initialize()` with `start_time = Some(now)` (boundary — accepted)
+- `claim()` before cliff when start is in the future (returns `CliffNotReached`)
+- `claim()` at and after cliff with future start (returns correct amount)
+- `get_vesting_schedule()` reflects the configured start time

--- a/.kiro/specs/vesting-configurable-start-time/requirements.md
+++ b/.kiro/specs/vesting-configurable-start-time/requirements.md
@@ -1,0 +1,60 @@
+# Requirements Document
+
+## Introduction
+
+The `forge-vesting` contract currently sets `start_time` to `env.ledger().timestamp()` at initialization, meaning vesting always begins immediately at deployment. Real-world use cases — such as employee vesting that should begin on a future hire date — require the ability to pre-schedule a future start time. This feature adds an optional `start_time` parameter to `initialize()` so deployers can specify when vesting should begin, while preserving the existing default behaviour when no start time is provided.
+
+## Glossary
+
+- **ForgeVesting**: The Soroban smart contract that manages token vesting schedules.
+- **VestingConfig**: The on-chain storage struct that holds all configuration for an active vesting schedule.
+- **initialize()**: The one-time setup function that configures a vesting schedule.
+- **start_time**: The ledger timestamp (seconds since Unix epoch) at which vesting begins and elapsed time starts accumulating.
+- **cliff_seconds**: The number of seconds after `start_time` before any tokens unlock.
+- **duration_seconds**: The total length of the vesting schedule in seconds, measured from `start_time`.
+- **compute_vested**: The internal function that calculates how many tokens have vested based on elapsed time since `start_time`.
+- **InvalidConfig**: The `VestingError` variant returned when initialization parameters are logically invalid.
+- **Ledger timestamp**: The current on-chain time returned by `env.ledger().timestamp()`, used as the reference for "now".
+
+## Requirements
+
+### Requirement 1: Optional Start Time Parameter
+
+**User Story:** As a contract deployer, I want to optionally specify a future `start_time` when initializing a vesting schedule, so that I can pre-schedule vesting to begin at a known future date without needing to deploy at exactly that moment.
+
+#### Acceptance Criteria
+
+1. THE `ForgeVesting` SHALL accept an optional `start_time: Option<u64>` parameter in `initialize()`.
+2. WHEN `start_time` is `None`, THE `ForgeVesting` SHALL set `VestingConfig.start_time` to `env.ledger().timestamp()`, preserving current behaviour.
+3. WHEN `start_time` is `Some(t)` and `t >= env.ledger().timestamp()`, THE `ForgeVesting` SHALL set `VestingConfig.start_time` to `t`.
+4. WHEN `start_time` is `Some(t)` and `t < env.ledger().timestamp()`, THE `ForgeVesting` SHALL return `VestingError::InvalidConfig`.
+5. WHEN `start_time` is `Some(t)` and `t == env.ledger().timestamp()`, THE `ForgeVesting` SHALL set `VestingConfig.start_time` to `t` and treat it as a valid present-time start.
+
+### Requirement 2: VestingConfig Storage
+
+**User Story:** As a contract integrator, I want `VestingConfig` to store the actual resolved start time, so that downstream reads via `get_config()` and `get_vesting_schedule()` always reflect the true start time of the schedule.
+
+#### Acceptance Criteria
+
+1. THE `VestingConfig` SHALL store the resolved `start_time` value (whether defaulted or explicitly provided) after a successful `initialize()` call.
+2. WHEN `get_config()` is called after initialization, THE `ForgeVesting` SHALL return a `VestingConfig` whose `start_time` field equals the value passed to `initialize()` (or `env.ledger().timestamp()` if `None` was passed).
+3. WHEN `get_vesting_schedule()` is called after initialization, THE `ForgeVesting` SHALL return a `VestingSchedule` whose `start_time` field equals the resolved start time.
+
+### Requirement 3: Claim Correctness with Configured Start Time
+
+**User Story:** As a beneficiary, I want `claim()` to correctly compute vested tokens relative to the configured `start_time`, so that I cannot claim tokens before vesting has actually begun and tokens unlock on the correct schedule.
+
+#### Acceptance Criteria
+
+1. WHEN the current ledger timestamp is before `VestingConfig.start_time + cliff_seconds`, THE `ForgeVesting` SHALL return `VestingError::CliffNotReached` from `claim()`.
+2. WHEN the current ledger timestamp is at or after `VestingConfig.start_time + cliff_seconds`, THE `ForgeVesting` SHALL allow `claim()` to proceed and return the correct vested amount.
+3. WHEN `compute_vested` is called with a `now` value less than `VestingConfig.start_time`, THE `ForgeVesting` SHALL return `0` vested tokens.
+4. WHEN `compute_vested` is called with a `now` value equal to `VestingConfig.start_time + duration_seconds`, THE `ForgeVesting` SHALL return `total_amount` as the vested amount.
+
+### Requirement 4: Documentation Update
+
+**User Story:** As a developer integrating the contract, I want the `initialize()` doc comment to describe the new `start_time` parameter, so that I understand its semantics, default behaviour, and validation rules without reading the source code.
+
+#### Acceptance Criteria
+
+1. THE `ForgeVesting` `initialize()` function doc comment SHALL document the `start_time` parameter, including its type (`Option<u64>`), default behaviour when `None`, and the `InvalidConfig` error condition when a past timestamp is supplied.

--- a/.kiro/specs/vesting-configurable-start-time/tasks.md
+++ b/.kiro/specs/vesting-configurable-start-time/tasks.md
@@ -1,0 +1,71 @@
+# Implementation Plan: Vesting Configurable Start Time
+
+## Overview
+
+Incremental implementation of the optional `start_time` parameter for `ForgeVesting::initialize()`. Each task builds on the previous and ends with all components wired together and tested.
+
+## Tasks
+
+- [ ] 1. Add `start_time: Option<u64>` parameter to `initialize()` and resolve it
+  - In `contracts/forge-vesting/src/lib.rs`, add `start_time: Option<u64>` as the last parameter of `initialize()`
+  - Insert resolution logic: `None` → `env.ledger().timestamp()`; `Some(t)` where `t < env.ledger().timestamp()` → `return Err(VestingError::InvalidConfig)`; `Some(t)` → `t`
+  - Replace the inline `env.ledger().timestamp()` in the `VestingConfig` construction with `resolved_start`
+  - The existing `InvalidConfig` guard (`total_amount <= 0`, `duration_seconds == 0`, `cliff_seconds > duration_seconds`) remains unchanged
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1_
+
+  - [ ]* 1.1 Write unit tests for start_time resolution
+    - Test `None` → defaults to ledger timestamp (backward-compat)
+    - Test `Some(future_t)` → stored verbatim
+    - Test `Some(past_t)` → returns `VestingError::InvalidConfig`
+    - Test `Some(now)` → accepted (boundary edge case)
+    - _Requirements: 1.2, 1.3, 1.4, 1.5_
+
+- [ ] 2. Update `initialize()` doc comment
+  - Add `start_time` to the `# Parameters` section: document `Option<u64>` type, `None` default behaviour, and the `InvalidConfig` error when a past timestamp is supplied
+  - _Requirements: 4.1_
+
+- [ ] 3. Add `proptest` dev-dependency and write property-based tests
+  - Add `proptest = "1"` under `[dev-dependencies]` in `contracts/forge-vesting/Cargo.toml`
+
+  - [ ]* 3.1 Property 1 — None defaults to ledger timestamp
+    - Generate random ledger timestamps; call `initialize()` with `start_time = None`; assert `get_config().start_time == now`
+    - Annotate: `// Feature: vesting-configurable-start-time, Property 1: None start_time defaults to ledger timestamp`
+    - _Requirements: 1.2, 2.2_
+
+  - [ ]* 3.2 Property 2 — Future start_time stored verbatim
+    - Generate random `t >= now`; call `initialize()` with `start_time = Some(t)`; assert `get_config().start_time == t`
+    - Annotate: `// Feature: vesting-configurable-start-time, Property 2: Future start_time is stored verbatim`
+    - _Requirements: 1.3, 2.1, 2.2_
+
+  - [ ]* 3.3 Property 3 — Past start_time rejected
+    - Generate random `t < now`; call `initialize()` with `start_time = Some(t)`; assert `Err(VestingError::InvalidConfig)`
+    - Annotate: `// Feature: vesting-configurable-start-time, Property 3: Past start_time is rejected`
+    - _Requirements: 1.4_
+
+  - [ ]* 3.4 Property 4 — get_vesting_schedule reflects resolved start_time
+    - Generate valid configs (None and Some(future)); assert `get_vesting_schedule().start_time == get_config().start_time`
+    - Annotate: `// Feature: vesting-configurable-start-time, Property 4: get_vesting_schedule reflects resolved start_time`
+    - _Requirements: 2.3_
+
+  - [ ]* 3.5 Property 5 — Vesting amount correctness relative to configured start_time
+    - Generate valid configs with future `start_time`; generate `now` across the full timeline (before cliff, between cliff and duration, at duration); assert vested amount matches the linear formula
+    - Covers edge cases: `now < start_time` → 0 vested; `now == start_time + duration_seconds` → `total_amount`
+    - Annotate: `// Feature: vesting-configurable-start-time, Property 5: Vesting amount correctness relative to configured start_time`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 4. Write unit tests for claim() with a future start_time
+  - Test `claim()` before cliff when `start_time` is in the future → `VestingError::CliffNotReached`
+  - Test `claim()` at exactly `start_time + cliff_seconds` → succeeds and returns correct amount
+  - Test `claim()` at `start_time + duration_seconds` → returns `total_amount`
+  - Test `get_vesting_schedule()` returns the configured `start_time`
+  - _Requirements: 3.1, 3.2, 2.3_
+
+- [ ] 5. Checkpoint — Ensure all tests pass
+  - Run `cargo test -p forge-vesting` and confirm all existing and new tests pass. Ask the user if any questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- `compute_vested` requires no changes — it already reads `config.start_time`
+- `VestingConfig` requires no schema changes — `start_time: u64` already exists
+- All existing callers of `initialize()` must pass `None` as the new last argument to preserve current behaviour


### PR DESCRIPTION
Add requirements, design, and tasks for optional start_time parameter in ForgeVesting::initialize(). Allows deployers to pre-schedule a future vesting start rather than always starting at deployment time. Past timestamps are rejected with InvalidConfig.

## What does this PR do?
[Provide a summary of the changes]

## Related issue
[Link to the issue, e.g. #123]

## Testing done
[Describe the tests you ran to verify your changes]

## Checklist
- [  ] I have run `cargo fmt` (or equivalent formatter)
- [  ] I have run `cargo clippy` (or equivalent linter)
- [  ] All tests pass locally
- [  ] I have labeled this PR with 'good first issue' or 'dx' where applicable.
closes #305 