### PR TITLE
test(forge-oracle): verify attacker signing for admin address is rejected

### DIFF
--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -675,6 +675,53 @@ mod tests {
         assert!(result.is_err(), "initialize must revert when signer does not control the admin address");
     }
 
+    /// Verifies the two-phase auth scenario for initialize():
+    /// Phase 1 — an attacker mocks auth for the admin address but is not that address;
+    ///            require_auth() on admin fails because attacker did not sign for admin.
+    /// Phase 2 — the real admin mocks auth for their own address; require_auth() succeeds.
+    /// Post-init — get_admin() returns admin, not attacker.
+    #[test]
+    fn test_attacker_signing_for_admin_address_is_rejected() {
+        use soroban_sdk::IntoVal;
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ForgeOracle);
+        let client = ForgeOracleClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        // Phase 1: attacker signs, but initialize() is called with admin as the admin arg.
+        // admin.require_auth() checks that admin signed — attacker did not, so this must fail.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, 3600u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = client.try_initialize(&admin, &3600);
+        assert!(result.is_err(), "initialize must revert when attacker signs for admin address");
+
+        // Phase 2: admin signs for their own address — require_auth() is satisfied.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, 3600u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = client.try_initialize(&admin, &3600);
+        assert!(result.is_ok(), "initialize must succeed when admin signs for their own address");
+
+        // Post-init: get_admin() must return admin, not attacker.
+        assert_eq!(client.get_admin(), admin, "get_admin() must return the admin address");
+        assert_ne!(client.get_admin(), attacker, "get_admin() must not return the attacker address");
+    }
+
     #[test]
     fn test_transfer_admin() {
         let env = Env::default();


### PR DESCRIPTION
## Summary

Adds `test_attacker_signing_for_admin_address_is_rejected` to the forge-oracle test suite.

## Motivation

The existing `test_initialize_admin_must_sign_for_supplied_address` covers a caller nominating a third-party address without that party's signature. No test covered the complementary scenario: an attacker explicitly forging the admin's auth — mocking auth with `address: &attacker` but passing `&admin` as the initialize argument — and still being rejected.

## What this test does

**Phase 1 (attacker):** Mocks auth as `attacker` signing for an `initialize` call that passes `admin` as the admin argument. `admin.require_auth()` fails because `attacker` did not sign for `admin`. Asserts `try_initialize` returns `Err`.

**Phase 2 (admin):** Mocks auth as `admin` signing for their own address. `require_auth()` is satisfied. Asserts `try_initialize` returns `Ok`.

**Post-init:** Asserts `get_admin() == admin` and `get_admin() != attacker`.

## Notes
- No `mock_all_auths()` used anywhere in the test
- The 2 pre-existing failures (`test_get_price_reverts_if_staleness_threshold_missing`, `test_transfer_admin_new_admin_can_submit_old_admin_cannot`) are unrelated to this change and fail on `main` as well
closes #276 