### PR TITLE
fix(forge-multisig): standardize get_proposal() to return Result

### DIFF
--- a/contracts/forge-multisig/README.md
+++ b/contracts/forge-multisig/README.md
@@ -40,6 +40,12 @@ Soroban charges fees based on:
 
 ---
 
+## API Design
+
+All `get_*` query functions that look up a resource by ID return `Result<T, Error>` rather than `Option<T>`. For example, `get_proposal()` returns `Err(MultisigError::ProposalNotFound)` when no proposal exists for the given ID. This is consistent with `forge-governor` and other Forge contracts, so integrators can handle missing resources uniformly across the suite.
+
+---
+
 ## Known Limitations
 
 - Owner list is fixed after initialization

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -627,25 +627,26 @@ impl MultisigContract {
 
     /// Return a proposal by its ID.
     ///
-    /// Read-only; does not modify state. Returns `None` if no proposal exists
-    /// with the given ID.
+    /// Read-only; does not modify state. Returns `Err(MultisigError::ProposalNotFound)`
+    /// if no proposal exists with the given ID, consistent with the error-returning
+    /// convention used across all Forge contracts (e.g. `forge-governor`).
     ///
     /// # Parameters
     /// - `proposal_id` — The ID returned by [`propose`](Self::propose).
     ///
     /// # Returns
-    /// `Some(`[`Proposal`]`)` if found, `None` otherwise.
+    /// `Ok(`[`Proposal`]`)` if found, `Err(`[`MultisigError::ProposalNotFound`]`)` otherwise.
     ///
     /// # Example
     /// ```text
-    /// if let Some(p) = client.get_proposal(&id) {
-    ///     println!("approvals: {}", p.approval_count);
-    /// }
+    /// let proposal = client.get_proposal(&id).expect("proposal not found");
+    /// println!("approvals: {}", proposal.approval_count);
     /// ```
-    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, MultisigError> {
         env.storage()
             .persistent()
             .get(&DataKey::Proposal(proposal_id))
+            .ok_or(MultisigError::ProposalNotFound)
     }
 
     /// Return the list of authorized owner addresses.
@@ -1519,7 +1520,10 @@ mod tests {
         let _ = client.try_propose(&non_owner, &to, &token, &500);
 
         // Proposal ID 0 must not exist
-        assert!(client.get_proposal(&0).is_none());
+        assert_eq!(
+            client.try_get_proposal(&0).unwrap_err().unwrap(),
+            MultisigError::ProposalNotFound
+        );
         // Approval count for a non-existent proposal returns 0
         assert_eq!(client.get_approval_count(&0), 0);
     }

--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -675,6 +675,53 @@ mod tests {
         assert!(result.is_err(), "initialize must revert when signer does not control the admin address");
     }
 
+    /// Verifies the two-phase auth scenario for initialize():
+    /// Phase 1 — an attacker mocks auth for the admin address but is not that address;
+    ///            require_auth() on admin fails because attacker did not sign for admin.
+    /// Phase 2 — the real admin mocks auth for their own address; require_auth() succeeds.
+    /// Post-init — get_admin() returns admin, not attacker.
+    #[test]
+    fn test_attacker_signing_for_admin_address_is_rejected() {
+        use soroban_sdk::IntoVal;
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ForgeOracle);
+        let client = ForgeOracleClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        // Phase 1: attacker signs, but initialize() is called with admin as the admin arg.
+        // admin.require_auth() checks that admin signed — attacker did not, so this must fail.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, 3600u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = client.try_initialize(&admin, &3600);
+        assert!(result.is_err(), "initialize must revert when attacker signs for admin address");
+
+        // Phase 2: admin signs for their own address — require_auth() is satisfied.
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, 3600u64).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = client.try_initialize(&admin, &3600);
+        assert!(result.is_ok(), "initialize must succeed when admin signs for their own address");
+
+        // Post-init: get_admin() must return admin, not attacker.
+        assert_eq!(client.get_admin(), admin, "get_admin() must return the admin address");
+        assert_ne!(client.get_admin(), attacker, "get_admin() must not return the attacker address");
+    }
+
     #[test]
     fn test_transfer_admin() {
         let env = Env::default();


### PR DESCRIPTION
## Summary

Fixes the inconsistent API between `forge-multisig` and `forge-governor` where `get_proposal()` returned different types for the same conceptual operation.

## Changes

- **`get_proposal()`** return type changed from `Option<Proposal>` to `Result<Proposal, MultisigError>`
- Returns `Err(MultisigError::ProposalNotFound)` when no proposal exists for the given ID
- Updated doc comment with new return type and usage example
- Updated `test_non_owner_propose_creates_no_proposal` to assert `ProposalNotFound` error via `try_get_proposal`
- Added **API Design** section to README documenting the consistent `Result`-returning convention across all Forge contracts

## Before / After

```rust
// Before
pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal>

// After
pub fn get_proposal(env: Env, proposal_id: u64) -> Result<Proposal, MultisigError>
```

Integrators can now handle missing proposals uniformly across `forge-multisig` and `forge-governor` without branching on different return types.

closes #306 