### PR TITLE
fix(forge-governor): store vote weight as i128 and add get_vote_weigh…

### DIFF
--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -401,7 +401,7 @@ impl GovernorContract {
             VoteDirection::Abstain => proposal.abstentions += weight,
         }
 
-        env.storage().persistent().set(&vote_key, &true);
+        env.storage().persistent().set(&vote_key, &weight);
         env.storage()
             .persistent()
             .extend_ttl(&vote_key, VOTE_TTL_EXTEND, VOTE_TTL_EXTEND);
@@ -770,6 +770,30 @@ impl GovernorContract {
         env.storage()
             .persistent()
             .has(&DataKey::Vote(proposal_id, voter))
+    }
+
+    /// Return the weight a voter cast on a specific proposal.
+    ///
+    /// Looks up the persistent vote entry written by [`vote`](Self::vote).
+    /// Returns `Some(weight)` if the voter has cast a vote, or `None` if they
+    /// have not voted (or if the proposal does not exist).
+    ///
+    /// # Parameters
+    /// - `proposal_id` — ID of the proposal to query.
+    /// - `voter` — Address of the voter to look up.
+    ///
+    /// # Returns
+    /// `Some(i128)` — the weight the voter cast, or `None` if no vote was found.
+    ///
+    /// # Example
+    /// ```text
+    /// let weight = client.get_vote_weight(&proposal_id, &voter_address);
+    /// assert_eq!(weight, Some(500));
+    /// ```
+    pub fn get_vote_weight(env: Env, proposal_id: u64, voter: Address) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Vote(proposal_id, voter))
     }
 
     /// Return the current state of a proposal.
@@ -2703,5 +2727,70 @@ mod tests {
         assert_eq!(stored.voting_period, 7200);
         assert_eq!(stored.quorum, 50);
         assert_eq!(stored.timelock_delay, 43200);
+    }
+
+    #[test]
+    fn test_get_vote_weight_returns_correct_weight_after_voting() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        mint(&env, &token_id, &voter, 500);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "P"),
+            &String::from_str(&env, "D"),
+        );
+
+        // Before voting, weight should be None
+        assert_eq!(client.get_vote_weight(&pid, &voter), None);
+
+        client.vote(&voter, &pid, &VoteDirection::For, &500);
+
+        // After voting, weight should match what was cast
+        assert_eq!(client.get_vote_weight(&pid, &voter), Some(500));
+    }
+
+    #[test]
+    fn test_get_vote_weight_returns_none_for_non_voter() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        let non_voter = Address::generate(&env);
+        mint(&env, &token_id, &voter, 100);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "P"),
+            &String::from_str(&env, "D"),
+        );
+
+        client.vote(&voter, &pid, &VoteDirection::Against, &75);
+
+        // voter's weight is stored
+        assert_eq!(client.get_vote_weight(&pid, &voter), Some(75));
+        // non_voter never voted — must return None
+        assert_eq!(client.get_vote_weight(&pid, &non_voter), None);
+    }
+
+    #[test]
+    fn test_get_vote_weight_returns_none_for_nonexistent_proposal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = setup(&env);
+
+        let voter = Address::generate(&env);
+
+        // Proposal 999 was never created
+        assert_eq!(client.get_vote_weight(&999, &voter), None);
     }
 }

--- a/contracts/forge-stream/src/lib.rs
+++ b/contracts/forge-stream/src/lib.rs
@@ -563,14 +563,21 @@ impl ForgeStream {
     /// - `withdrawn`: Cumulative withdrawn
     /// - `withdrawable`: streamed - withdrawn
     /// - `remaining`: total - streamed
-    /// - `is_active`: !cancelled && !paused && now < end_time
+    /// - `is_active`: `true` when the stream is currently accruing tokens
+    ///   (`!cancelled && !paused && now < end_time`). A paused or finished
+    ///   stream has `is_active = false` even if tokens remain claimable.
     /// - `is_finished`: now >= end_time
-    /// - `is_claimable`: withdrawable > 0
+    /// - `is_paused`: stream is currently paused
+    /// - `is_claimable`: `true` when `withdrawable > 0`. Independent of
+    ///   `is_active` — a paused or finished stream can still be claimable.
+    ///   Always check `is_claimable` (not `is_active`) to decide whether a
+    ///   withdrawal is available.
     ///
-    /// **Note:** `is_active = false` does **not** imply `withdrawable = 0`.
-    /// A finished stream (`is_finished = true`) may still have tokens available
-    /// to withdraw. Always check `is_claimable` or `withdrawable` directly
-    /// before assuming nothing can be claimed.
+    /// **Note:** `is_active` and `is_claimable` are intentionally separate.
+    /// `is_active` answers "is this stream accruing right now?" while
+    /// `is_claimable` answers "can the recipient withdraw tokens right now?".
+    /// A paused stream stops accruing (`is_active = false`) but tokens that
+    /// accrued before the pause remain withdrawable (`is_claimable = true`).
     ///
     /// # Example
     /// ```rust,ignore
@@ -3026,5 +3033,35 @@ mod tests {
             total,
             "withdrawable + returnable must equal total even with paused time"
         );
+    }
+
+    /// A paused stream stops accruing (is_active = false) but tokens that
+    /// accrued before the pause are still claimable (is_claimable = true).
+    /// This guards against UIs that check is_active to show a withdraw button.
+    #[test]
+    fn test_paused_stream_is_not_active_but_is_claimable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ForgeStream);
+        let client = ForgeStreamClient::new(&env, &contract_id);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let token = setup_token(&env, &sender, 100 * 1000);
+
+        // 100 tokens/s for 1000s
+        let stream_id = client.create_stream(&sender, &token, &recipient, &100, &1000);
+
+        // Advance 200s so 20,000 tokens have accrued
+        env.ledger().with_mut(|l| l.timestamp += 200);
+
+        // Pause — accrual stops but 20,000 tokens are still withdrawable
+        client.pause_stream(&stream_id);
+
+        let status = client.get_stream_status(&stream_id);
+
+        assert!(status.is_paused, "stream should be paused");
+        assert!(!status.is_active, "paused stream must not be active (not accruing)");
+        assert_eq!(status.withdrawable, 20_000, "20,000 tokens accrued before pause");
+        assert!(status.is_claimable, "paused stream with accrued tokens must be claimable");
     }
 }


### PR DESCRIPTION


closes #304

Problem

When a voter cast a vote, only true was written to persistent storage under DataKey::Vote(proposal_id, voter). The actual weight was accumulated into proposal.votes_for / proposal.votes_against / proposal.abstentions but never stored against the individual voter. This meant:

There was no way to look up how much weight a specific voter cast
Off-chain audits and recounts had no per-voter breakdown available
has_voted() could confirm participation but not the amount
Changes

vote() — stores weight: i128 instead of true at the vote key. The key and TTL logic are unchanged, so double-vote protection and has_voted() continue to work exactly as before
has_voted() — no change. Still uses .has() on the same key, external API is identical
get_vote_weight(proposal_id: u64, voter: Address) -> Option<i128> — new read-only view function. Returns Some(weight) if the voter has voted, None otherwise (covers non-voters and nonexistent proposals)
Tests added

test_get_vote_weight_returns_correct_weight_after_voting — verifies None before voting and the exact weight after
test_get_vote_weight_returns_none_for_non_voter — verifies a non-participating address returns None while the actual voter returns their weight
test_get_vote_weight_returns_none_for_nonexistent_proposal — verifies graceful None for a proposal that was never created