### PR TITLE
dx: add FORGE_PRECOMMIT_TESTS flag to pre-commit hook and document it

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,4 +13,18 @@ cp scripts/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
+### Enabling Tests in the Hook
+
+By default the hook only runs `cargo fmt` and `cargo clippy`. To also run the full test suite before each commit, set the `FORGE_PRECOMMIT_TESTS` environment variable to `1`:
+
+```bash
+# Run tests on this commit only
+FORGE_PRECOMMIT_TESTS=1 git commit -m "your message"
+
+# Enable tests permanently for your local repo
+export FORGE_PRECOMMIT_TESTS=1
+```
+
+> **Tip:** If you're adding new tests, use `FORGE_PRECOMMIT_TESTS=1 git commit` to verify they pass before pushing.
+
 See [CONTRIBUTING.md](../CONTRIBUTING.md#pre-commit-hook-optional-but-recommended) for more details.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -16,13 +16,15 @@ if ! cargo clippy --all-targets -- -D warnings; then
     exit 1
 fi
 
-# Run tests (optional - can be slow for large projects)
-# Uncomment the following lines if you want to run tests before each commit:
-# echo "Running tests..."
-# if ! cargo test --workspace; then
-#     echo "❌ Tests failed. Fix them before committing."
-#     exit 1
-# fi
+# Run tests (controlled by FORGE_PRECOMMIT_TESTS env var)
+# Set FORGE_PRECOMMIT_TESTS=1 to enable: FORGE_PRECOMMIT_TESTS=1 git commit
+if [ "${FORGE_PRECOMMIT_TESTS:-0}" = "1" ]; then
+    echo "Running tests (FORGE_PRECOMMIT_TESTS=1)..."
+    if ! cargo test --workspace; then
+        echo "❌ Tests failed. Fix them before committing."
+        exit 1
+    fi
+fi
 
 echo "✅ All pre-commit checks passed!"
 exit 0


### PR DESCRIPTION
Closes #342
Closes #341
Closes #340
Closes #339 


Contributors who wanted pre-commit test validation had to manually edit the script with no documented way to enable it.

Changes:

Updated scripts/pre-commit to check ${FORGE_PRECOMMIT_TESTS:-0} — if set to 1, the full cargo test --workspace runs before each commit; otherwise it's skipped
Updated 
README.md
 to document the flag, how to use it per-commit and permanently, and added a tip for contributors adding new tests
Note: CONTRIBUTING.md already references the hook setup; the flag is self-documenting via the script comment