### PR TITLE
feat: add default env config and optional setup section in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Stellar / Soroban Configuration
+
+# Network
+STELLAR_NETWORK=testnet
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Identity (used with `stellar keys`)
+STELLAR_IDENTITY=default
+
+# Optional: frequently used contract IDs
+FORGE_ORACLE_CONTRACT_ID=
+FORGE_STREAM_CONTRACT_ID=
+FORGE_VESTING_CONTRACT_ID=
+
+# Logging
+RUST_LOG=info

--- a/README.md
+++ b/README.md
@@ -305,6 +305,23 @@ Replace `<your-identity-name>` with any label you like (e.g. `alice`). The `--fu
 
 ---
 
+## ⚙️ Optional: Environment Configuration
+
+For convenience, you can store commonly used values in a `.env` file.
+
+1. Copy the example:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Fill in values like network, identity, or contract IDs.
+
+> Note: The project does not require `.env` to run. This is only for developer convenience when working with repeated CLI commands.
+
+
+---
+
 ### Make command reference
 
 | Command | Description |


### PR DESCRIPTION
### 📘 Description

Adds a default `.env.example` file and an optional environment configuration section in the README to improve developer onboarding.

### ✅ Changes

* Added `.env.example` with Stellar/Soroban config placeholders
* Updated README with optional `.env` setup instructions

### 💡 Notes

This does not introduce any required configuration or dependencies. The `.env` file is optional and intended for convenience when working with repeated CLI commands.

### 🧪 Testing

* Verified existing setup flow remains unchanged
* Confirmed instructions align with current CLI usage
close #408 
