### PR TITLE
Add README files for contracts, forge-vesting-factory, and crates

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,23 @@
+# Contracts
+
+This folder contains StellarForge Soroban smart contracts.
+
+## Purpose
+
+- Hosts reusable on-chain primitives for governance, treasury control, payments, vesting, and oracle data.
+- Keeps each primitive isolated in its own crate for independent testing and deployment.
+
+## Structure
+
+- `forge-governor`: Token-weighted governance and proposal lifecycle.
+- `forge-multisig`: N-of-M treasury approvals with timelock.
+- `forge-oracle`: Admin-managed price feed with staleness checks.
+- `forge-stream`: Real-time token streaming and withdrawals.
+- `forge-vesting`: Single-beneficiary token vesting schedule.
+- `forge-vesting-factory`: Multi-schedule vesting from one deployment.
+
+Each contract follows the same pattern:
+
+- `Cargo.toml`: crate manifest
+- `src/lib.rs`: contract logic, types, errors, and tests
+- `README.md`: contract-specific behavior and notes

--- a/contracts/forge-vesting-factory/README.md
+++ b/contracts/forge-vesting-factory/README.md
@@ -1,0 +1,22 @@
+# Forge Vesting Factory
+
+A single deployment that manages many vesting schedules.
+
+## Purpose
+
+- Create multiple vesting schedules without deploying one contract per beneficiary.
+- Reduce deployment and operational overhead for team/investor token distributions.
+
+## Core Functions
+
+- `create_schedule(token, beneficiary, admin, total_amount, cliff_seconds, duration_seconds) -> schedule_id`
+- `claim(schedule_id)`
+- `cancel(schedule_id)`
+- `get_status(schedule_id)`
+- `get_schedule_count()`
+
+## Notes
+
+- Each schedule has its own token, beneficiary, admin, amount, cliff, and duration.
+- On creation, tokens are transferred from admin into the factory contract.
+- On cancel, vested amounts remain claimable while unvested amounts return to admin.

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,14 @@
+# Crates
+
+This folder contains shared Rust crates used by multiple contracts in the workspace.
+
+## Purpose
+
+- Centralize reusable logic used across contract crates.
+- Reduce duplication and keep cross-contract behavior consistent.
+
+## Current Crates
+
+- `forge-errors`: Shared common error variants used across StellarForge contracts.
+
+As the project grows, new shared libraries can be added here when functionality is used by multiple contracts.


### PR DESCRIPTION
## Summary
closes #403
This PR adds missing README documentation to key project folders so contributors can quickly understand each folder’s purpose and contents.

## Changes
- Added [contracts/README.md](contracts/README.md)
- Added [crates/README.md](crates/README.md)
- Added [contracts/forge-vesting-factory/README.md](contracts/forge-vesting-factory/README.md)

## What These READMEs Cover
- Folder purpose and responsibility
- High-level structure of contained modules and crates
- Contract-specific overview for vesting factory, including core functions and behavior notes

## Acceptance Criteria Mapping
- README in main folders: Completed
- Folder purpose explained: Completed

## Scope
- Documentation only
- No contract logic or runtime behavior changes
- No unrelated refactors or formatting sweeps
