### PR TITLE
Improve variable naming in vesting factory schedule flows

### DIFF
--- a/contracts/forge-vesting-factory/src/lib.rs
+++ b/contracts/forge-vesting-factory/src/lib.rs
@@ -111,13 +111,13 @@ impl ForgeVestingFactory {
             return Err(FactoryError::Common(CommonError::InvalidConfig));
         }
 
-        let id: u64 = env
+        let schedule_id: u64 = env
             .storage()
             .instance()
             .get(&DataKey::ScheduleCount)
             .unwrap_or(0);
 
-        let config = ScheduleConfig {
+        let schedule_config = ScheduleConfig {
             token: token.clone(),
             beneficiary,
             admin,
@@ -130,22 +130,22 @@ impl ForgeVestingFactory {
 
         // Pull tokens from admin into the contract
         token::Client::new(&env, &token).transfer(
-            &config.admin,
+            &schedule_config.admin,
             &env.current_contract_address(),
             &total_amount,
         );
 
         env.storage()
             .persistent()
-            .set(&DataKey::Schedule(id), &config);
+            .set(&DataKey::Schedule(schedule_id), &schedule_config);
         env.storage()
             .instance()
-            .set(&DataKey::ScheduleCount, &(id + 1));
+            .set(&DataKey::ScheduleCount, &(schedule_id + 1));
 
         env.events()
-            .publish((Symbol::new(&env, "schedule_created"),), (id, total_amount));
+            .publish((Symbol::new(&env, "schedule_created"),), (schedule_id, total_amount));
 
-        Ok(id)
+        Ok(schedule_id)
     }
 
     /// Claim all currently vested and unclaimed tokens for a schedule.
@@ -164,28 +164,28 @@ impl ForgeVestingFactory {
     /// - [`FactoryError::CliffNotReached`]
     /// - [`FactoryError::NothingToClaim`]
     pub fn claim(env: Env, schedule_id: u64) -> Result<i128, FactoryError> {
-        let config: ScheduleConfig = env
+        let schedule_config: ScheduleConfig = env
             .storage()
             .persistent()
             .get(&DataKey::Schedule(schedule_id))
             .ok_or(FactoryError::ScheduleNotFound)?;
 
-        config.beneficiary.require_auth();
+        schedule_config.beneficiary.require_auth();
 
-        if config.cancelled {
+        if schedule_config.cancelled {
             return Err(FactoryError::Cancelled);
         }
 
-        let now = env.ledger().timestamp();
-        let vested = Self::compute_vested(&config, now);
+        let current_time = env.ledger().timestamp();
+        let vested = Self::compute_vested(&schedule_config, current_time);
         let claimed: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Claimed(schedule_id))
             .unwrap_or(0);
 
-        let elapsed = now.saturating_sub(config.start_time);
-        if elapsed < config.cliff_seconds {
+        let elapsed = current_time.saturating_sub(schedule_config.start_time);
+        if elapsed < schedule_config.cliff_seconds {
             return Err(FactoryError::CliffNotReached);
         }
 
@@ -198,9 +198,9 @@ impl ForgeVestingFactory {
             .persistent()
             .set(&DataKey::Claimed(schedule_id), &(claimed + claimable));
 
-        token::Client::new(&env, &config.token).transfer(
+        token::Client::new(&env, &schedule_config.token).transfer(
             &env.current_contract_address(),
-            &config.beneficiary,
+            &schedule_config.beneficiary,
             &claimable,
         );
 
@@ -222,52 +222,52 @@ impl ForgeVestingFactory {
     /// - [`FactoryError::Cancelled`]
     /// - [`FactoryError::Unauthorized`]
     pub fn cancel(env: Env, schedule_id: u64) -> Result<(), FactoryError> {
-        let mut config: ScheduleConfig = env
+        let mut schedule_config: ScheduleConfig = env
             .storage()
             .persistent()
             .get(&DataKey::Schedule(schedule_id))
             .ok_or(FactoryError::ScheduleNotFound)?;
 
-        config.admin.require_auth();
+        schedule_config.admin.require_auth();
 
-        if config.cancelled {
+        if schedule_config.cancelled {
             return Err(FactoryError::Cancelled);
         }
 
-        let now = env.ledger().timestamp();
-        let vested = Self::compute_vested(&config, now);
+        let current_time = env.ledger().timestamp();
+        let vested = Self::compute_vested(&schedule_config, current_time);
         let claimed: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Claimed(schedule_id))
             .unwrap_or(0);
 
-        let token = token::Client::new(&env, &config.token);
+        let token_client = token::Client::new(&env, &schedule_config.token);
 
         // Send unclaimed vested tokens to beneficiary
         let beneficiary_amount = (vested - claimed).max(0);
         if beneficiary_amount > 0 {
-            token.transfer(
+            token_client.transfer(
                 &env.current_contract_address(),
-                &config.beneficiary,
+                &schedule_config.beneficiary,
                 &beneficiary_amount,
             );
         }
 
         // Return unvested tokens to admin
-        let admin_amount = (config.total_amount - vested).max(0);
+        let admin_amount = (schedule_config.total_amount - vested).max(0);
         if admin_amount > 0 {
-            token.transfer(
+            token_client.transfer(
                 &env.current_contract_address(),
-                &config.admin,
+                &schedule_config.admin,
                 &admin_amount,
             );
         }
 
-        config.cancelled = true;
+        schedule_config.cancelled = true;
         env.storage()
             .persistent()
-            .set(&DataKey::Schedule(schedule_id), &config);
+            .set(&DataKey::Schedule(schedule_id), &schedule_config);
 
         env.events()
             .publish((Symbol::new(&env, "schedule_cancelled"),), (schedule_id,));
@@ -288,22 +288,22 @@ impl ForgeVestingFactory {
     /// # Errors
     /// - [`FactoryError::ScheduleNotFound`]
     pub fn get_status(env: Env, schedule_id: u64) -> Result<VestingStatus, FactoryError> {
-        let config: ScheduleConfig = env
+        let schedule_config: ScheduleConfig = env
             .storage()
             .persistent()
             .get(&DataKey::Schedule(schedule_id))
             .ok_or(FactoryError::ScheduleNotFound)?;
 
-        let now = env.ledger().timestamp();
-        let vested = Self::compute_vested(&config, now);
+        let current_time = env.ledger().timestamp();
+        let vested = Self::compute_vested(&schedule_config, current_time);
         let claimed: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Claimed(schedule_id))
             .unwrap_or(0);
 
-        let elapsed = now.saturating_sub(config.start_time);
-        let claimable = if elapsed >= config.cliff_seconds {
+        let elapsed = current_time.saturating_sub(schedule_config.start_time);
+        let claimable = if elapsed >= schedule_config.cliff_seconds {
             (vested - claimed).max(0)
         } else {
             0
@@ -311,13 +311,13 @@ impl ForgeVestingFactory {
 
         Ok(VestingStatus {
             schedule_id,
-            total_amount: config.total_amount,
+            total_amount: schedule_config.total_amount,
             claimed,
             vested,
             claimable,
-            cliff_reached: elapsed >= config.cliff_seconds,
-            fully_vested: vested >= config.total_amount,
-            cancelled: config.cancelled,
+            cliff_reached: elapsed >= schedule_config.cliff_seconds,
+            fully_vested: vested >= schedule_config.total_amount,
+            cancelled: schedule_config.cancelled,
         })
     }
 


### PR DESCRIPTION
# PR Description

## Summary

This PR improves local variable naming in the vesting factory contract to make intent clearer and code easier to understand, while preserving existing behavior.

## What Changed

- Renamed ambiguous local variables to descriptive names in schedule creation, claim, cancel, and status paths.
- Representative renames:
  - `id` -> `schedule_id`
  - `config` -> `schedule_config`
  - `now` -> `current_time`
  - local `token` client variable -> `token_client`

## Scope

- Refactor-only change.
- No logic changes.
- No storage/schema/API changes.
- No unrelated file modifications included in this fix.

## Validation

- Performed a targeted crate check for `forge-vesting-factory`.
- Confirmed the rename refactor does not introduce new crate-specific errors.
- Existing repository-wide compilation failures are pre-existing and unrelated to this naming change.

## Linked Issue

Closes #395
