### PR TITLE
test(forge-vesting): verify paused time excluded from vested amounts

### DIFF
--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -1778,6 +1778,50 @@ mod tests {
         assert_eq!(config.start_time + config.duration_seconds, expected_end);
     }
 
+    /// Verifies that paused time is excluded from vested amounts and claim().
+    ///
+    /// Timeline (cliff=0, duration=1000, total=10_000, start_time=0):
+    ///   t=0    initialize  → vested = 0
+    ///   t=200  pause       → vested = 10_000 * 200/1000 = 2_000 (frozen)
+    ///   t=400  unpause     → start_time shifts to 200 (paused 200s)
+    ///   t=600  check       → active elapsed = (600-200) = 400s
+    ///                        vested = 10_000 * 400/1000 = 4_000
+    ///   t=600  claim()     → returns 4_000
+    ///   t=1200 check       → active elapsed = (1200-200) = 1000s → fully vested
+    #[test]
+    fn test_unpause_paused_time_excluded_from_vested_amounts() {
+        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        client.initialize(&token_id, &beneficiary, &admin, &10_000, &0, &1000);
+
+        // t=200: pause — 200s active → vested = 2_000
+        env.ledger().with_mut(|l| l.timestamp = 200);
+        client.pause();
+        assert_eq!(client.get_status().vested, 2_000);
+
+        // t=400: unpause — paused for 200s, start_time shifts to 200
+        env.ledger().with_mut(|l| l.timestamp = 400);
+        client.unpause();
+        assert_eq!(client.get_config().start_time, 200);
+
+        // t=600: 200s pre-pause + 200s post-resume = 400 active seconds
+        // vested = 10_000 * 400/1000 = 4_000
+        env.ledger().with_mut(|l| l.timestamp = 600);
+        let status = client.get_status();
+        assert_eq!(status.vested, 4_000, "vested at t=600 should be 4_000");
+        assert!(!status.fully_vested);
+
+        let claimed = client.claim();
+        assert_eq!(claimed, 4_000, "claim() at t=600 should return 4_000");
+
+        // t=1200: active elapsed = 1200 - 200 = 1000s → fully vested
+        env.ledger().with_mut(|l| l.timestamp = 1200);
+        let status = client.get_status();
+        assert!(status.fully_vested, "should be fully vested at t=1200");
+        assert_eq!(status.vested, 10_000);
+    }
+
     /// Test 4: Non-admin cannot pause or unpause.
     #[test]
     fn test_non_admin_cannot_pause_or_unpause() {


### PR DESCRIPTION
Closes #334

---

## Summary

Adds `test_unpause_paused_time_excluded_from_vested_amounts` to cover the `unpause()` start_time shift producing correct vested amounts and `claim()` output.

## Timeline covered

| Time | Action | Assert |
|------|--------|--------|
| t=0 | initialize (cliff=0, duration=1000, total=10_000) | — |
| t=200 | pause | vested=2_000 (frozen) |
| t=400 | unpause | start_time shifted to 200 |
| t=600 | get_status + claim | vested=4_000, claim()=4_000 |
| t=1200 | get_status | fully_vested=true |