### PR TITLE
docs: fix spelling and grammar in comments and text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,6 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 ## Environment Info
-- OS: [e.g. Windows 11]
-- Version: [e.g. 1.0.0]
-- Browser/Tool: [e.g. Chrome, VS Code]
+- OS: [e.g., Windows 11]
+- Version: [e.g., 1.0.0]
+- Browser/Tool: [e.g., Chrome, VS Code]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 [Provide a summary of the changes]
 
 ## Related issue
-[Link to the issue, e.g. #123]
+[Link to the issue, e.g., #123]
 
 ## Testing done
 [Describe the tests you ran to verify your changes]

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If you want to deploy contracts to Stellar testnet, generate and fund a test ide
 stellar keys generate <your-identity-name> --network testnet --fund
 ```
 
-Replace `<your-identity-name>` with any label you like (e.g. `alice`). The `--fund` flag automatically requests test tokens from the Stellar Friendbot.
+Replace `<your-identity-name>` with any label you like (e.g., `alice`). The `--fund` flag automatically requests test tokens from the Stellar Friendbot.
 
 ---
 

--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -212,7 +212,7 @@ impl GovernorContract {
             return Err(GovernorError::Common(CommonError::InvalidConfig));
         }
         // Sanity-check: vote_token must not be the same address as admin.
-        // A misconfigured vote_token (e.g. admin address used by mistake) would pass
+        // A misconfigured vote_token (e.g., admin address used by mistake) would pass
         // initialization silently but fail at vote() time. This catches the most obvious
         // misconfiguration early with a descriptive error.
         if config.vote_token == config.admin {
@@ -228,8 +228,8 @@ impl GovernorContract {
     /// Create a new governance proposal.
     ///
     /// Opens a new proposal for voting immediately, with `vote_end` set to
-    /// `current_timestamp + voting_period`. The proposer's approval is not
-    /// automatically recorded — owners must call [`vote`](Self::vote) separately.
+    /// `current_timestamp + voting_period`. The proposer's vote is not
+    /// automatically recorded — voters must call [`vote`](Self::vote) separately.
     /// Requires authorization from `proposer`.
     ///
     /// # Parameters

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -784,7 +784,7 @@ impl MultisigContract {
     ///
     /// Read-only; does not modify state. Returns `Err(MultisigError::ProposalNotFound)`
     /// if no proposal exists with the given ID, consistent with the error-returning
-    /// convention used across all Forge contracts (e.g. `forge-governor`).
+    /// convention used across all Forge contracts (e.g., `forge-governor`).
     ///
     /// # Parameters
     /// - `proposal_id` — The ID returned by [`propose`](Self::propose).
@@ -840,7 +840,7 @@ impl MultisigContract {
     ///
     /// # Example
     /// ```text
-    /// let threshold = client.get_threshold(); // e.g. 2 for a 2-of-3 setup
+    /// let threshold = client.get_threshold(); // e.g., 2 for a 2-of-3 setup
     /// ```
     pub fn get_threshold(env: Env) -> u32 {
         env.storage()
@@ -2615,7 +2615,7 @@ mod tests {
         assert_eq!(xlm_client.balance(&recipient), 50_000_000);
     }
 
-    /// If execute() traps before the transfer completes (e.g. InsufficientFunds),
+    /// If execute() traps before the transfer completes (e.g., InsufficientFunds),
     /// proposal.executed must remain false so the proposal can be retried once
     /// the treasury is funded. This guards against the pre-transfer executed=true
     /// bug that would permanently lock funds.

--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -40,7 +40,7 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PriceData {
-    /// Price scaled to 7 decimal places (e.g. 1_0000000 = 1.0)
+    /// Price scaled to 7 decimal places (e.g., 1_0000000 = 1.0)
     pub price: i128,
     /// Ledger timestamp of last update
     pub updated_at: u64,
@@ -290,7 +290,7 @@ impl ForgeOracle {
     ///
     /// - `env`: The Soroban environment.
     /// - `new_threshold`: The new maximum age of a price in seconds. A price is
-    ///   considered stale when `now >= updated_at + threshold`, i.e. the threshold
+    ///   considered stale when `now >= updated_at + threshold`, i.e., the threshold
     ///   is exclusive: a price is valid while `now < updated_at + threshold` and
     ///   stale at exactly `now == updated_at + threshold`.
     ///
@@ -349,7 +349,7 @@ impl ForgeOracle {
     /// for the same pair. A value of `0` disables the circuit breaker (default).
     ///
     /// # Parameters
-    /// - `bps`: Maximum deviation in basis points (e.g. `1000` = 10%). `0` disables the check.
+    /// - `bps`: Maximum deviation in basis points (e.g., `1000` = 10%). `0` disables the check.
     ///
     /// # Errors
     /// - [`OracleError::NotInitialized`] — contract not initialized

--- a/contracts/forge-vesting-factory/src/lib.rs
+++ b/contracts/forge-vesting-factory/src/lib.rs
@@ -9,7 +9,7 @@
 //! - Each schedule has its own token, beneficiary, admin, cliff, and duration
 //! - Beneficiaries call `claim(schedule_id)` to withdraw unlocked tokens
 //! - Admins call `cancel(schedule_id)` to cancel a schedule and reclaim unvested tokens
-//! - Reduces deployment costs dramatically for multi-beneficiary vesting (e.g. employee grants)
+//! - Reduces deployment costs dramatically for multi-beneficiary vesting (e.g., employee grants)
 
 use forge_errors::CommonError;
 use soroban_sdk::{

--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -2172,7 +2172,7 @@ mod tests {
     }
 
     /// Verifies that no "admin_transferred" event is emitted when transfer_admin() fails
-    /// (e.g. SameAdmin case).
+    /// (e.g., SameAdmin case).
     #[test]
     fn test_event_admin_transferred_not_emitted_on_failure() {
         use soroban_sdk::{testutils::Events, Symbol, TryFromVal};


### PR DESCRIPTION
Closes #381

---

Fixes spelling and grammar issues across comments and documentation. No functional changes.

## Changes

| File | Fix |
|------|-----|
| `forge-governor/src/lib.rs` | "owners must call vote" → "voters must call vote" (semantic: any token holder votes, not just "owners"); `e.g.` → `e.g.,` |
| `forge-oracle/src/lib.rs` | `e.g.` → `e.g.,` (×2); `i.e.` → `i.e.,` |
| `forge-multisig/src/lib.rs` | `e.g.` → `e.g.,` (×3) |
| `forge-vesting/src/lib.rs` | `e.g.` → `e.g.,` |
| `forge-vesting-factory/src/lib.rs` | `e.g.` → `e.g.,` |
| `README.md` | `e.g.` → `e.g.,` |
| `.github/ISSUE_TEMPLATE/bug_report.md` | `e.g.` → `e.g.,` (×3) |
| `.github/PULL_REQUEST_TEMPLATE.md` | `e.g.` → `e.g.,` |

The standard English convention is `e.g.,` and `i.e.,` (comma after the abbreviation).