### PR TITLE
docs: add .env.example for contributor setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# StellarForge Environment Configuration
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# .env is listed in .gitignore — never commit real keys or secrets.
+
+# ── Network ───────────────────────────────────────────────────────────────────
+
+# Target network: testnet | mainnet | local
+STELLAR_NETWORK=testnet
+
+# Soroban RPC endpoint for the target network
+# Testnet:  https://soroban-testnet.stellar.org
+# Mainnet:  https://soroban.stellar.org
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Network passphrase (must match STELLAR_NETWORK)
+# Testnet:  Test SDF Network ; September 2015
+# Mainnet:  Public Global Stellar Network ; September 2015
+STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# ── Identity ──────────────────────────────────────────────────────────────────
+
+# Name of the Stellar CLI identity to use for signing transactions
+# Create one with: stellar keys generate <name> --network testnet --fund
+STELLAR_IDENTITY=alice
+
+# ── Deployed Contract Addresses ───────────────────────────────────────────────
+# Populate these after deploying with: stellar contract deploy ...
+
+FORGE_VESTING_CONTRACT_ID=
+FORGE_VESTING_FACTORY_CONTRACT_ID=
+FORGE_STREAM_CONTRACT_ID=
+FORGE_MULTISIG_CONTRACT_ID=
+FORGE_GOVERNOR_CONTRACT_ID=
+FORGE_ORACLE_CONTRACT_ID=


### PR DESCRIPTION
Closes #382

---

Adds `.env.example` so contributors know exactly what environment variables to set before using the Stellar CLI.

## Variables included

| Variable | Purpose |
|----------|---------|
| `STELLAR_NETWORK` | Target network (`testnet` / `mainnet` / `local`) |
| `STELLAR_RPC_URL` | Soroban RPC endpoint |
| `STELLAR_NETWORK_PASSPHRASE` | Network passphrase for signing |
| `STELLAR_IDENTITY` | Stellar CLI key name for signing transactions |
| `FORGE_*_CONTRACT_ID` | Placeholder for each deployed contract address |

`.env` is already in `.gitignore`, so real values are never committed.