### PR TITLE
Format code consistently and fix workspace configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,18 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "forge-benches"
-version = "0.1.0"
-dependencies = [
- "forge-governor",
- "forge-multisig",
- "forge-oracle",
- "forge-stream",
- "forge-vesting",
- "soroban-sdk",
-]
-
-[[package]]
 name = "forge-errors"
 version = "0.1.0"
 dependencies = [
@@ -488,6 +476,7 @@ dependencies = [
 name = "forge-governor"
 version = "0.1.0"
 dependencies = [
+ "forge-errors",
  "soroban-sdk",
 ]
 
@@ -495,6 +484,7 @@ dependencies = [
 name = "forge-multisig"
 version = "0.1.0"
 dependencies = [
+ "forge-errors",
  "soroban-sdk",
 ]
 
@@ -510,6 +500,7 @@ dependencies = [
 name = "forge-stream"
 version = "0.1.0"
 dependencies = [
+ "forge-errors",
  "soroban-sdk",
 ]
 
@@ -517,6 +508,7 @@ dependencies = [
 name = "forge-vesting"
 version = "0.1.0"
 dependencies = [
+ "forge-errors",
  "soroban-sdk",
 ]
 
@@ -524,6 +516,7 @@ dependencies = [
 name = "forge-vesting-factory"
 version = "0.1.0"
 dependencies = [
+ "forge-errors",
  "soroban-sdk",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,11 @@ members = [
     "contracts/forge-multisig",
     "contracts/forge-governor",
     "contracts/forge-oracle",
-    "benches",
 ]
 
 [workspace.dependencies]
 soroban-sdk = { version = "21.7.6" }
-forge-errors = { workspace = true }
+forge-errors = { path = "crates/forge-errors" }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/forge-oracle/src/lib.rs
+++ b/contracts/forge-oracle/src/lib.rs
@@ -11,9 +11,7 @@
 //! - Event emission on every price update
 
 use forge_errors::CommonError;
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Vec};
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
@@ -192,7 +190,9 @@ impl ForgeOracle {
                 quote: quote.clone(),
             });
             env.storage().persistent().set(&DataKey::Pairs, &pairs);
-            env.storage().persistent().extend_ttl(&DataKey::Pairs, 17280, 34560);
+            env.storage()
+                .persistent()
+                .extend_ttl(&DataKey::Pairs, 17280, 34560);
         }
 
         env.storage()


### PR DESCRIPTION
- Fix workspace dependencies: properly define forge-errors path
- Remove non-existent benches member from workspace
- Apply rustfmt to all compilable contracts
- Ensure consistent indentation across codebase

Note: forge-governor and forge-stream have pre-existing syntax errors that prevent formatting. These need to be fixed separately.

Closes #387

## What does this PR do?
[Provide a summary of the changes]

## Related issue
[Link to the issue, e.g. #123]

## Testing done
[Describe the tests you ran to verify your changes]

## Checklist
- [  ] I have run `cargo fmt` (or equivalent formatter)
- [  ] I have run `cargo clippy` (or equivalent linter)
- [  ] All tests pass locally
- [  ] I have labeled this PR with 'good first issue' or 'dx' where applicable.
