### PR TITLE
fix: correct error variants and remove double-write in execute()

### DIFF
--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -153,8 +153,7 @@ pub enum GovernorError {
     AlreadyCancelled = 12,
     InvalidWeight = 13,
     AlreadyFinalized = 14,
-    Unauthorized = 14,
-    AlreadyFinalized = 15,
+    Unauthorized = 15,
     VoteNotFound = 16,
 }
 
@@ -374,6 +373,11 @@ impl GovernorContract {
             .get(&DataKey::Config)
             .ok_or(GovernorError::Common(CommonError::NotInitialized))?;
 
+        // Reject zero or negative weight before any storage reads or token calls.
+        if weight <= 0 {
+            return Err(GovernorError::InvalidWeight);
+        }
+
         // Enforce 1-token-1-vote: reject if claimed weight exceeds actual balance.
         let actual_balance = token::Client::new(&env, &config.vote_token).balance(&voter);
         if weight > actual_balance {
@@ -398,10 +402,6 @@ impl GovernorContract {
         let now = env.ledger().timestamp();
         if now >= proposal.vote_end {
             return Err(GovernorError::VotingClosed);
-        }
-
-        if weight <= 0 {
-            return Err(GovernorError::InvalidWeight);
         }
 
         match direction {
@@ -1560,7 +1560,7 @@ mod tests {
             &String::from_str(&env, "P"),
             &String::from_str(&env, "D"),
         );
-        client.vote(&voter, &pid, &true, &200);
+        client.vote(&voter, &pid, &VoteDirection::For, &200);
 
         // Finalize at a known timestamp
         let finalize_time: u64 = 5000;
@@ -3037,6 +3037,31 @@ mod tests {
     /// Test finalize() still works correctly with Active proposals (normal case)
     #[test]
     fn test_finalize_active_proposal_still_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        mint(&env, &token_id, &voter, 200);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "Test Proposal"),
+            &String::from_str(&env, "Description"),
+        );
+
+        // Vote and advance past voting period
+        client.vote(&voter, &pid, &VoteDirection::For, &200);
+        env.ledger().with_mut(|l| l.timestamp = 5000);
+
+        // Finalize should work normally for Active proposals
+        let state = client.finalize(&pid);
+        assert_eq!(state, ProposalState::Passed);
+        assert_eq!(client.get_proposal_state(&pid), ProposalState::Passed);
+    }
+
     // ── Issue #335: abstain votes count toward quorum but not toward passing ──
 
     /// Scenario 1: 100 abstain votes meet quorum (100) but proposal fails because
@@ -3141,6 +3166,17 @@ mod tests {
         env.ledger().with_mut(|l| l.timestamp = 1000 + 3600 + 1);
         let result2 = client.try_finalize(&pid);
         assert_eq!(result2, Err(Ok(GovernorError::AlreadyCancelled)));
+    }
+
+    /// Scenario 2: 51 for + 49 abstain = 100 total meets quorum and yes majority → Passed.
+    #[test]
+    fn test_for_plus_abstain_meets_quorum_and_passes() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
         let yes_voter = Address::generate(&env);
         let abstainer = Address::generate(&env);
         mint(&env, &token_id, &yes_voter, 51);

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -601,11 +601,6 @@ impl MultisigContract {
             return Err(MultisigError::TimelockNotElapsed);
         }
 
-        proposal.executed = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Proposal(proposal_id), &proposal);
-
         let token_client = token::Client::new(&env, &proposal.token);
 
         // Verify the treasury holds enough to cover all committed proposals.

--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -199,6 +199,7 @@ impl ForgeVesting {
     /// # Errors
     /// - [`VestingError::NotInitialized`] — `initialize` has not been called.
     /// - [`VestingError::Cancelled`] — The vesting schedule was cancelled by the admin.
+    /// - [`VestingError::Paused`] — The vesting schedule is currently paused.
     /// - [`VestingError::CliffNotReached`] — Current time is before `start_time + cliff_seconds`.
     /// - [`VestingError::NothingToClaim`] — All vested tokens have already been claimed.
     ///
@@ -219,7 +220,7 @@ impl ForgeVesting {
         }
 
         if config.paused {
-            return Err(VestingError::Common(CommonError::Unauthorized));
+            return Err(VestingError::Paused);
         }
 
         config.beneficiary.require_auth();
@@ -359,7 +360,7 @@ impl ForgeVesting {
             return Err(VestingError::Cancelled);
         }
         if config.paused {
-            return Err(VestingError::Common(CommonError::Unauthorized));
+            return Err(VestingError::Paused);
         }
 
         config.admin.require_auth();
@@ -635,6 +636,7 @@ impl ForgeVesting {
     ///
     /// # Errors
     /// - [`VestingError::NotInitialized`] — Contract not initialized.
+    /// - [`VestingError::Cancelled`] — The vesting schedule has been cancelled.
     /// - [`VestingError::Paused`] — Already paused.
     pub fn pause(env: Env) -> Result<(), VestingError> {
         let mut config: VestingConfig = env
@@ -650,7 +652,7 @@ impl ForgeVesting {
         }
 
         if config.paused {
-            return Err(VestingError::Common(CommonError::Unauthorized));
+            return Err(VestingError::Paused);
         }
 
         config.paused = true;
@@ -668,7 +670,8 @@ impl ForgeVesting {
     ///
     /// # Errors
     /// - [`VestingError::NotInitialized`] — Contract not initialized.
-    /// - [`VestingError::NotPaused`] — Not currently paused.
+    /// - [`VestingError::Cancelled`] — The vesting schedule has been cancelled.
+    /// - [`VestingError::NotPaused`] — Schedule is not currently paused.
     pub fn unpause(env: Env) -> Result<(), VestingError> {
         let mut config: VestingConfig = env
             .storage()
@@ -683,7 +686,7 @@ impl ForgeVesting {
         }
 
         if !config.paused {
-            return Err(VestingError::Common(CommonError::NotInitialized));
+            return Err(VestingError::NotPaused);
         }
 
         let now = env.ledger().timestamp();
@@ -1713,7 +1716,7 @@ mod tests {
     // ── Pause / Unpause Tests ─────────────────────────────────────────────────
 
     /// Test 1: Admin pauses at 50% vesting. Verify get_status shows amount frozen
-    /// and claim() fails with Paused.
+    /// and claim() fails with VestingError::Paused.
     #[test]
     fn test_pause_freezes_vested_amount_and_blocks_claim() {
         let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
@@ -1729,7 +1732,7 @@ mod tests {
         assert!(status.paused);
         assert_eq!(status.vested, 500_000); // frozen at 50%
 
-        // claim must fail
+        // claim must fail with Paused, not Unauthorized
         assert_eq!(client.try_claim(), Err(Ok(VestingError::Paused)));
     }
 


### PR DESCRIPTION
forge-vesting:
- claim(): return VestingError::Paused instead of Unauthorized
- cancel_and_claim(): return VestingError::Paused instead of Unauthorized
- pause(): return VestingError::Paused (already-paused) instead of Unauthorized
- unpause(): return VestingError::NotPaused instead of NotInitialized
- Update doc comments and test assertion comment to reference correct variants

forge-multisig:
- execute(): remove pre-transfer proposal.executed=true write; keep only the post-transfer write so a failed transfer leaves the proposal retryable

forge-governor:
- vote(): move weight<=0 guard before token balance check and storage reads to short-circuit cheaply and prevent vote-slot consumption on invalid weight
- Fix duplicate GovernorError discriminants (AlreadyFinalized=14 appeared twice; Unauthorized now = 15, VoteNotFound = 16)
- Fix &true -> &VoteDirection::For in test
- Fix malformed test functions (missing body / merged test bodies)

## What does this PR do?
[Provide a summary of the changes]

## Related issue
closes #425 
closes #426 
closes #427 
closes #428 

## Testing done
[Describe the tests you ran to verify your changes]

## Checklist
- [  ] I have run `cargo fmt` (or equivalent formatter)
- [  ] I have run `cargo clippy` (or equivalent linter)
- [  ] All tests pass locally
- [  ] I have labeled this PR with 'good first issue' or 'dx' where applicable.
