### PR TITLE
fix: resolve security bugs #433, #434, #435 and add tests #436

### DIFF
--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -299,17 +299,25 @@ impl GovernorContract {
         // Track active proposal ID for O(1) get_pending_proposals
         let mut active: Vec<u64> = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::ActiveProposals)
             .unwrap_or_else(|| Vec::new(&env));
         let index = active.len();
         active.push_back(proposal_id);
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::ActiveProposals, &active);
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::ActiveProposalIndex(proposal_id), &index);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::ActiveProposals, PROPOSAL_TTL_EXTEND, PROPOSAL_TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::ActiveProposalIndex(proposal_id),
+            PROPOSAL_TTL_EXTEND,
+            PROPOSAL_TTL_EXTEND,
+        );
 
         env.events().publish(
             (Symbol::new(&env, "proposal_created"),),
@@ -891,7 +899,7 @@ impl GovernorContract {
     pub fn get_pending_proposals(env: Env) -> Vec<u64> {
         let active: Vec<u64> = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::ActiveProposals)
             .unwrap_or_else(|| Vec::new(&env));
 
@@ -916,17 +924,17 @@ impl GovernorContract {
 
     fn remove_active_proposal(env: &Env, proposal_id: u64) {
         let index_key = DataKey::ActiveProposalIndex(proposal_id);
-        let Some(index) = env.storage().instance().get::<DataKey, u32>(&index_key) else {
+        let Some(index) = env.storage().persistent().get::<DataKey, u32>(&index_key) else {
             return;
         };
 
         let mut active: Vec<u64> = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::ActiveProposals)
             .unwrap_or_else(|| Vec::new(env));
         if active.is_empty() {
-            env.storage().instance().remove(&index_key);
+            env.storage().persistent().remove(&index_key);
             return;
         }
 
@@ -935,15 +943,23 @@ impl GovernorContract {
             let last_id = active.get(last_index).unwrap();
             active.set(index, last_id);
             env.storage()
-                .instance()
+                .persistent()
                 .set(&DataKey::ActiveProposalIndex(last_id), &index);
+            env.storage().persistent().extend_ttl(
+                &DataKey::ActiveProposalIndex(last_id),
+                PROPOSAL_TTL_EXTEND,
+                PROPOSAL_TTL_EXTEND,
+            );
         }
 
         active.remove(last_index);
         env.storage()
-            .instance()
+            .persistent()
             .set(&DataKey::ActiveProposals, &active);
-        env.storage().instance().remove(&index_key);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::ActiveProposals, PROPOSAL_TTL_EXTEND, PROPOSAL_TTL_EXTEND);
+        env.storage().persistent().remove(&index_key);
     }
 }
 

--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -250,12 +250,17 @@ impl MultisigContract {
         if approved_at.is_some() {
             let committed: i128 = env
                 .storage()
-                .instance()
+                .persistent()
                 .get(&DataKey::CommittedAmount(token.clone()))
                 .unwrap_or(0);
-            env.storage().instance().set(
+            env.storage().persistent().set(
                 &DataKey::CommittedAmount(token.clone()),
                 &(committed + amount),
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::CommittedAmount(token.clone()),
+                31536000,
+                31536000,
             );
         }
 
@@ -359,12 +364,17 @@ impl MultisigContract {
         if approved_at.is_some() {
             let committed: i128 = env
                 .storage()
-                .instance()
+                .persistent()
                 .get(&DataKey::CommittedAmount(xlm_token.clone()))
                 .unwrap_or(0);
-            env.storage().instance().set(
+            env.storage().persistent().set(
                 &DataKey::CommittedAmount(xlm_token.clone()),
                 &(committed + amount),
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::CommittedAmount(xlm_token.clone()),
+                31536000,
+                31536000,
             );
         }
 
@@ -450,12 +460,17 @@ impl MultisigContract {
             // Track committed tokens to prevent over-commitment across concurrent proposals
             let committed: i128 = env
                 .storage()
-                .instance()
+                .persistent()
                 .get(&DataKey::CommittedAmount(proposal.token.clone()))
                 .unwrap_or(0);
-            env.storage().instance().set(
+            env.storage().persistent().set(
                 &DataKey::CommittedAmount(proposal.token.clone()),
                 &(committed + proposal.amount),
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::CommittedAmount(proposal.token.clone()),
+                31536000,
+                31536000,
             );
         }
 
@@ -614,7 +629,7 @@ impl MultisigContract {
         // in `proposal.token`, so the call is identical in both cases.
         let committed: i128 = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::CommittedAmount(proposal.token.clone()))
             .unwrap_or(0);
         let balance = token_client.balance(&env.current_contract_address());
@@ -638,9 +653,14 @@ impl MultisigContract {
 
         // Release the committed amount for this proposal
         let new_committed = committed.saturating_sub(proposal.amount);
-        env.storage().instance().set(
+        env.storage().persistent().set(
             &DataKey::CommittedAmount(proposal.token.clone()),
             &new_committed,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::CommittedAmount(proposal.token.clone()),
+            31536000,
+            31536000,
         );
 
         env.storage().instance().extend_ttl(17280, 34560);
@@ -703,12 +723,18 @@ impl MultisigContract {
             if proposal.approved_at.is_some() {
                 let committed: i128 = env
                     .storage()
-                    .instance()
+                    .persistent()
                     .get(&DataKey::CommittedAmount(proposal.token.clone()))
                     .unwrap_or(0);
-                env.storage().instance().set(
+                let new_committed = committed.saturating_sub(proposal.amount);
+                env.storage().persistent().set(
                     &DataKey::CommittedAmount(proposal.token.clone()),
-                    &committed.saturating_sub(proposal.amount),
+                    &new_committed,
+                );
+                env.storage().persistent().extend_ttl(
+                    &DataKey::CommittedAmount(proposal.token.clone()),
+                    31536000,
+                    31536000,
                 );
             }
             env.storage()
@@ -753,12 +779,18 @@ impl MultisigContract {
             if proposal.approved_at.is_some() {
                 let committed: i128 = env
                     .storage()
-                    .instance()
+                    .persistent()
                     .get(&DataKey::CommittedAmount(proposal.token.clone()))
                     .unwrap_or(0);
-                env.storage().instance().set(
+                let new_committed = committed.saturating_sub(proposal.amount);
+                env.storage().persistent().set(
                     &DataKey::CommittedAmount(proposal.token.clone()),
-                    &committed.saturating_sub(proposal.amount),
+                    &new_committed,
+                );
+                env.storage().persistent().extend_ttl(
+                    &DataKey::CommittedAmount(proposal.token.clone()),
+                    31536000,
+                    31536000,
                 );
             }
             env.storage()
@@ -928,7 +960,7 @@ impl MultisigContract {
     /// `i128` — total committed tokens for `token`. Returns `0` if none committed.
     pub fn get_committed_amount(env: Env, token: Address) -> i128 {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::CommittedAmount(token))
             .unwrap_or(0)
     }

--- a/contracts/forge-vesting-factory/src/lib.rs
+++ b/contracts/forge-vesting-factory/src/lib.rs
@@ -242,10 +242,24 @@ impl ForgeVestingFactory {
             .get(&DataKey::Claimed(schedule_id))
             .unwrap_or(0);
 
+        let beneficiary_amount = (vested - claimed).max(0);
+        let admin_amount = (config.total_amount - vested).max(0);
+
+        // Write state before any transfers to prevent double-pay on retry.
+        config.cancelled = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Schedule(schedule_id), &config);
+        // Record the beneficiary payout as claimed so a retry cannot re-pay it.
+        if beneficiary_amount > 0 {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Claimed(schedule_id), &(claimed + beneficiary_amount));
+        }
+
         let token = token::Client::new(&env, &config.token);
 
         // Send unclaimed vested tokens to beneficiary
-        let beneficiary_amount = (vested - claimed).max(0);
         if beneficiary_amount > 0 {
             token.transfer(
                 &env.current_contract_address(),
@@ -255,7 +269,6 @@ impl ForgeVestingFactory {
         }
 
         // Return unvested tokens to admin
-        let admin_amount = (config.total_amount - vested).max(0);
         if admin_amount > 0 {
             token.transfer(
                 &env.current_contract_address(),
@@ -263,11 +276,6 @@ impl ForgeVestingFactory {
                 &admin_amount,
             );
         }
-
-        config.cancelled = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Schedule(schedule_id), &config);
 
         env.events()
             .publish((Symbol::new(&env, "schedule_cancelled"),), (schedule_id,));
@@ -584,5 +592,262 @@ mod tests {
                 .unwrap_err(),
             Ok(FactoryError::InvalidConfig)
         );
+    }
+
+    // ── #436 comprehensive tests ──────────────────────────────────────────────
+
+    /// claim() at 25%, 50%, 75%, and 100% of vesting duration returns correct amounts.
+    #[test]
+    fn test_claim_at_quarter_intervals() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin, 1_000);
+        let tok = token::Client::new(&env, &token_addr);
+
+        // No cliff, 1000s duration, 1000 tokens
+        let id = client.create_schedule(&token_addr, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        // 25% — claim 250
+        env.ledger().with_mut(|l| l.timestamp = 250);
+        assert_eq!(client.claim(&id), 250);
+        assert_eq!(tok.balance(&beneficiary), 250);
+
+        // 50% — claim another 250
+        env.ledger().with_mut(|l| l.timestamp = 500);
+        assert_eq!(client.claim(&id), 250);
+        assert_eq!(tok.balance(&beneficiary), 500);
+
+        // 75% — claim another 250
+        env.ledger().with_mut(|l| l.timestamp = 750);
+        assert_eq!(client.claim(&id), 250);
+        assert_eq!(tok.balance(&beneficiary), 750);
+
+        // 100% — claim final 250
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+        assert_eq!(client.claim(&id), 250);
+        assert_eq!(tok.balance(&beneficiary), 1_000);
+    }
+
+    /// claim() before cliff reverts with CliffNotReached.
+    #[test]
+    fn test_claim_before_cliff_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token = setup_token(&env, &admin, 1_000);
+
+        // 500s cliff, 1000s duration
+        let id = client.create_schedule(&token, &beneficiary, &admin, &1_000, &500, &1_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 499);
+        assert_eq!(
+            client.try_claim(&id).unwrap_err(),
+            Ok(FactoryError::CliffNotReached)
+        );
+    }
+
+    /// cancel() at halfway: beneficiary gets vested tokens, admin gets remainder.
+    #[test]
+    fn test_cancel_at_halfway_splits_correctly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin, 1_000);
+        let tok = token::Client::new(&env, &token_addr);
+
+        let id = client.create_schedule(&token_addr, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 500);
+        client.cancel(&id);
+
+        assert_eq!(tok.balance(&beneficiary), 500);
+        assert_eq!(tok.balance(&admin), 500);
+
+        let status = client.get_status(&id);
+        assert!(status.cancelled);
+    }
+
+    /// cancel() on an already-cancelled schedule reverts with Cancelled.
+    #[test]
+    fn test_cancel_already_cancelled_reverts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token = setup_token(&env, &admin, 1_000);
+
+        let id = client.create_schedule(&token, &beneficiary, &admin, &1_000, &0, &1_000);
+        client.cancel(&id);
+
+        assert_eq!(
+            client.try_cancel(&id).unwrap_err(),
+            Ok(FactoryError::Cancelled)
+        );
+    }
+
+    /// get_status() after a partial claim reflects correct claimed and claimable values.
+    #[test]
+    fn test_get_status_after_partial_claim() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token = setup_token(&env, &admin, 1_000);
+
+        let id = client.create_schedule(&token, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 300);
+        client.claim(&id);
+
+        env.ledger().with_mut(|l| l.timestamp = 600);
+        let status = client.get_status(&id);
+        assert_eq!(status.claimed, 300);
+        assert_eq!(status.vested, 600);
+        assert_eq!(status.claimable, 300);
+        assert!(!status.fully_vested);
+        assert!(!status.cancelled);
+    }
+
+    /// Two concurrent schedules for different beneficiaries do not interfere.
+    #[test]
+    fn test_two_concurrent_schedules_no_interference() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let b1 = Address::generate(&env);
+        let b2 = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin, 2_000);
+        let tok = token::Client::new(&env, &token_addr);
+
+        let id1 = client.create_schedule(&token_addr, &b1, &admin, &1_000, &0, &1_000);
+        let id2 = client.create_schedule(&token_addr, &b2, &admin, &1_000, &0, &500);
+
+        env.ledger().with_mut(|l| l.timestamp = 500);
+
+        // id2 is fully vested; id1 is 50% vested
+        client.claim(&id2);
+        assert_eq!(tok.balance(&b2), 1_000);
+
+        // id1 unaffected
+        let s1 = client.get_status(&id1);
+        assert_eq!(s1.claimed, 0);
+        assert_eq!(s1.claimable, 500);
+
+        client.claim(&id1);
+        assert_eq!(tok.balance(&b1), 500);
+    }
+
+    /// get_schedule_count() increments correctly with each create_schedule() call.
+    #[test]
+    fn test_get_schedule_count_increments() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let token = setup_token(&env, &admin, 3_000);
+
+        assert_eq!(client.get_schedule_count(), 0);
+        for expected in 1u64..=3 {
+            let b = Address::generate(&env);
+            client.create_schedule(&token, &b, &admin, &1_000, &0, &1_000);
+            assert_eq!(client.get_schedule_count(), expected);
+        }
+    }
+
+    /// Non-beneficiary calling claim() reverts.
+    #[test]
+    fn test_non_beneficiary_cannot_claim() {
+        let env = Env::default();
+        // Do NOT mock_all_auths — we need real auth checking
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let token = setup_token(&env, &admin, 1_000);
+
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "create_schedule",
+                args: soroban_sdk::vec![
+                    &env,
+                    token.clone().into(),
+                    beneficiary.clone().into(),
+                    admin.clone().into(),
+                    1_000i128.into(),
+                    0u64.into(),
+                    1_000u64.into(),
+                ],
+                sub_invokes: &[],
+            },
+        }]);
+        let id = client.create_schedule(&token, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 500);
+
+        // attacker tries to claim — auth will fail
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "claim",
+                args: soroban_sdk::vec![&env, id.into()],
+                sub_invokes: &[],
+            },
+        }]);
+        // The contract calls beneficiary.require_auth() which will fail for attacker
+        let result = client.try_claim(&id);
+        assert!(result.is_err(), "non-beneficiary must not be able to claim");
+    }
+
+    /// Second cancel() call after a partial failure cannot double-pay the beneficiary.
+    /// Simulates the bug scenario from #433: state is written before transfers,
+    /// so a retry sees cancelled=true and returns Cancelled immediately.
+    #[test]
+    fn test_cancel_idempotent_no_double_pay() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin, 1_000);
+        let tok = token::Client::new(&env, &token_addr);
+
+        let id = client.create_schedule(&token_addr, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        env.ledger().with_mut(|l| l.timestamp = 400);
+        client.cancel(&id);
+
+        // Balances after first cancel: beneficiary=400, admin=600
+        assert_eq!(tok.balance(&beneficiary), 400);
+        assert_eq!(tok.balance(&admin), 600);
+
+        // Second cancel must revert — no double-pay
+        assert_eq!(
+            client.try_cancel(&id).unwrap_err(),
+            Ok(FactoryError::Cancelled)
+        );
+
+        // Balances unchanged
+        assert_eq!(tok.balance(&beneficiary), 400);
+        assert_eq!(tok.balance(&admin), 600);
     }
 }


### PR DESCRIPTION
#433 forge-vesting-factory: write config.cancelled and Claimed to persistent storage before token transfers in cancel() to prevent double-pay if the second transfer traps on retry.

#434 forge-multisig: move CommittedAmount from instance to persistent storage with 1-year extend_ttl so committed amounts survive TTL expiry and concurrent proposals cannot drain the treasury.

#435 forge-governor: move ActiveProposals and ActiveProposalIndex from instance to persistent storage with PROPOSAL_TTL_EXTEND (~60 days) so get_pending_proposals() and remove_active_proposal() remain correct after instance TTL expiry.

#436 forge-vesting-factory: add comprehensive tests covering claim at 25/50/75/100% intervals, cliff enforcement, cancel splits, double-cancel guard, get_status after partial claim, concurrent schedule isolation, schedule count, non-beneficiary auth, and double-pay regression.

Closes #433 
Closes #434 
Closes #435 
Closes #436 
