### PR TITLE
fix(forge-governor): move weight <= 0 check before balance read in vo…

### DIFF
--- a/contracts/forge-governor/src/lib.rs
+++ b/contracts/forge-governor/src/lib.rs
@@ -1302,6 +1302,68 @@ mod tests {
         assert_eq!(result, Err(Ok(GovernorError::InvalidWeight)));
     }
 
+    /// weight = -1 must return InvalidWeight without consuming the vote slot.
+    ///
+    /// Verifies that the weight <= 0 guard fires before the AlreadyVoted storage
+    /// write, so the voter can still cast a valid vote after the failed attempt.
+    #[test]
+    fn test_vote_negative_one_does_not_consume_vote_slot() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        mint(&env, &token_id, &voter, 100);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "P"),
+            &String::from_str(&env, "D"),
+        );
+
+        // Attempt with weight = -1 must fail with InvalidWeight
+        let result = client.try_vote(&voter, &pid, &VoteDirection::For, &-1);
+        assert_eq!(result, Err(Ok(GovernorError::InvalidWeight)));
+
+        // Vote slot must NOT have been consumed — voter can still vote successfully
+        assert!(!client.has_voted(&pid, &voter));
+        client.vote(&voter, &pid, &VoteDirection::For, &100);
+        assert!(client.has_voted(&pid, &voter));
+    }
+
+    /// weight = 0 must return InvalidWeight without consuming the vote slot.
+    ///
+    /// A voter with 0 balance would pass the balance check (0 > 0 is false),
+    /// so the weight <= 0 guard must fire first to prevent slot consumption.
+    #[test]
+    fn test_vote_zero_weight_does_not_consume_vote_slot() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let (client, token_id) = setup_with_token(&env);
+
+        let proposer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        mint(&env, &token_id, &voter, 50);
+
+        let pid = client.propose(
+            &proposer,
+            &String::from_str(&env, "P"),
+            &String::from_str(&env, "D"),
+        );
+
+        // Attempt with weight = 0 must fail with InvalidWeight
+        let result = client.try_vote(&voter, &pid, &VoteDirection::For, &0);
+        assert_eq!(result, Err(Ok(GovernorError::InvalidWeight)));
+
+        // Vote slot must NOT have been consumed — voter can still vote successfully
+        assert!(!client.has_voted(&pid, &voter));
+        client.vote(&voter, &pid, &VoteDirection::For, &50);
+        assert!(client.has_voted(&pid, &voter));
+    }
+
     #[test]
     fn test_get_proposal_existing() {
         let env = Env::default();


### PR DESCRIPTION
…te()

Closes #495

The weight <= 0 guard was placed after the token balance check, allowing callers with weight = -1 or weight = 0 to pass the balance check and trigger expensive AlreadyVoted and ProposalNotFound storage reads before being rejected.

Move the weight <= 0 check to the top of vote(), before any storage reads or token calls, so invalid weights are rejected cheaply.

Add tests:
- test_vote_negative_one_does_not_consume_vote_slot: verifies weight = -1 returns InvalidWeight without writing the vote slot, so the voter can still cast a valid vote afterward.
- test_vote_zero_weight_does_not_consume_vote_slot: verifies weight = 0 returns InvalidWeight without consuming the vote slot.

## Summary
[Provide a clear and concise summary of the changes made in this PR]

## Related issue
[Link to the issue, e.g., #123]
## Related Issue
[Link to the issue this PR addresses, e.g. Closes #123]

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
### Tests Performed
[Describe the tests you ran to verify your changes. Include:
- Unit tests run
- Integration tests performed
- Manual testing steps
- Any specific scenarios tested]

### Test Results
[All tests should pass. Include any test output or screenshots if relevant]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format the code
- [ ] I have run `cargo clippy` to lint the code
- [ ] All new and existing tests pass locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have labeled this PR appropriately (e.g., 'good first issue', 'documentation', 'bug')
- [ ] I have requested review from the appropriate maintainers

## Additional Notes
[Any additional context, screenshots, or information that reviewers should be aware of]
