### PR TITLE
fix(forge-vesting-factory): guard cancel() against fully vested sched…

### DIFF
--- a/contracts/forge-vesting-factory/src/lib.rs
+++ b/contracts/forge-vesting-factory/src/lib.rs
@@ -68,6 +68,9 @@ pub enum FactoryError {
     NothingToClaim = 4,
     Cancelled = 5,
     InvalidConfig = 6,
+    /// Returned by `cancel()` when the schedule has already fully vested.
+    /// Mirrors `VestingError::VestingComplete` in forge-vesting for consistency.
+    VestingComplete = 7,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -249,6 +252,12 @@ impl ForgeVestingFactory {
         }
 
         let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(config.start_time);
+
+        if elapsed >= config.duration_seconds {
+            return Err(FactoryError::VestingComplete);
+        }
+
         let vested = Self::compute_vested(&config, now);
         let claimed: i128 = env
             .storage()
@@ -979,6 +988,27 @@ mod tests {
         env.mock_auths(&[]);
         let result = client.try_claim(&id);
         assert!(result.is_err(), "non-beneficiary must not be able to claim");
+    }
+
+    /// cancel() on a fully vested schedule reverts with VestingComplete.
+    /// Mirrors forge-vesting behaviour for consistency (issue #498).
+    #[test]
+    fn test_cancel_fully_vested_reverts_with_vesting_complete() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 0);
+        let client = make_client(&env);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token = setup_token(&env, &admin, 1_000);
+
+        let id = client.create_schedule(&token, &beneficiary, &admin, &1_000, &0, &1_000);
+
+        // Advance past full duration — schedule is 100% vested
+        env.ledger().with_mut(|l| l.timestamp = 1_000);
+
+        let err = client.try_cancel(&id).unwrap_err();
+        assert_eq!(err, Ok(FactoryError::VestingComplete));
     }
 
     /// Second cancel() call after a partial failure cannot double-pay the beneficiary.

--- a/crates/forge-constants/src/lib.rs
+++ b/crates/forge-constants/src/lib.rs
@@ -53,6 +53,7 @@ pub mod error_codes {
         pub const NOTHING_TO_CLAIM: u32 = 4;
         pub const CANCELLED: u32 = 5;
         pub const INVALID_CONFIG: u32 = 6;
+        pub const VESTING_COMPLETE: u32 = 7;
     }
     
     pub mod governor {


### PR DESCRIPTION
…ules

forge-vesting (standalone) correctly rejects cancel() when elapsed >= duration_seconds with VestingError::VestingComplete. The factory's cancel() had no such guard, allowing the admin to force-send unclaimed tokens to the beneficiary on a fully vested schedule.

Changes:
- Add VestingComplete = 7 variant to FactoryError
- Add elapsed >= duration_seconds guard in cancel() before computing vested, mirroring forge-vesting behaviour
- Add error_codes::factory::VESTING_COMPLETE = 7 to forge-constants
- Add test_cancel_fully_vested_reverts_with_vesting_complete test

Closes #498

## Summary
[Provide a clear and concise summary of the changes made in this PR]

## Related issue
[Link to the issue, e.g., #123]
## Related Issue
[Link to the issue this PR addresses, e.g. Closes #123]

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
### Tests Performed
[Describe the tests you ran to verify your changes. Include:
- Unit tests run
- Integration tests performed
- Manual testing steps
- Any specific scenarios tested]

### Test Results
[All tests should pass. Include any test output or screenshots if relevant]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format the code
- [ ] I have run `cargo clippy` to lint the code
- [ ] All new and existing tests pass locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have labeled this PR appropriately (e.g., 'good first issue', 'documentation', 'bug')
- [ ] I have requested review from the appropriate maintainers

## Additional Notes
[Any additional context, screenshots, or information that reviewers should be aware of]
