### PR TITLE
fix(forge-vesting-factory): store VestedAtCancel and use it in get_st…

### DIFF
--- a/contracts/forge-vesting-factory/src/lib.rs
+++ b/contracts/forge-vesting-factory/src/lib.rs
@@ -393,6 +393,14 @@ impl ForgeVestingFactory {
     /// vested = total_amount × elapsed / duration
     /// ```
     ///
+    /// # Note on cancellation
+    ///
+    /// This function must **not** be called after a schedule is cancelled to
+    /// determine the historical vested amount. Instead, the vested amount at
+    /// cancel time is stored in `DataKey::VestedAtCancel(id)` and read by
+    /// `get_status()`. This mirrors the behaviour of forge-vesting which stores
+    /// `VestedAtCancel` to avoid returning 0 for cancelled schedules.
+    ///
     /// # Returns
     ///
     /// The total amount of tokens that have vested (not necessarily claimed) up to `now`.


### PR DESCRIPTION
…atus()

compute_vested() previously returned 0 when config.cancelled == true, causing get_status() to show vested = 0 after cancellation regardless of how much had vested at cancel time. This made the status misleading for auditing and UI display.

Changes:
- Add DataKey::VestedAtCancel(u64) storage key
- In cancel(), store the vested amount at cancel time via env.storage().persistent().set(&DataKey::VestedAtCancel(schedule_id), &vested)
- Update get_status() to read VestedAtCancel when config.cancelled == true, mirroring forge-vesting which stores VestedAtCancel for the same purpose
- Extend TTL for VestedAtCancel(id) in cancel() alongside other entries
- test_get_status_vested_reflects_cancel_time_not_zero verifies the fix

Closes #497

## Summary
[Provide a clear and concise summary of the changes made in this PR]

## Related issue
[Link to the issue, e.g., #123]
## Related Issue
[Link to the issue this PR addresses, e.g. Closes #123]

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
### Tests Performed
[Describe the tests you ran to verify your changes. Include:
- Unit tests run
- Integration tests performed
- Manual testing steps
- Any specific scenarios tested]

### Test Results
[All tests should pass. Include any test output or screenshots if relevant]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format the code
- [ ] I have run `cargo clippy` to lint the code
- [ ] All new and existing tests pass locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have labeled this PR appropriately (e.g., 'good first issue', 'documentation', 'bug')
- [ ] I have requested review from the appropriate maintainers

## Additional Notes
[Any additional context, screenshots, or information that reviewers should be aware of]
