### PR TITLE
fix(forge-vesting-factory): move ScheduleCount to persistent storage

### DIFF
--- a/contracts/forge-vesting-factory/README.md
+++ b/contracts/forge-vesting-factory/README.md
@@ -88,6 +88,14 @@ assert_eq!(factory.get_schedule_count(), 2);
 
 ---
 
+## Storage Strategy
+
+`ScheduleCount` is stored in **persistent** storage (not instance storage). This is critical: if `ScheduleCount` were in instance storage and that entry expired, the counter would reset to 0 and new schedules would silently overwrite existing ones in persistent storage, permanently destroying beneficiary vesting data.
+
+All per-schedule entries (`Schedule(id)`, `Claimed(id)`, `VestedAtCancel(id)`) are also stored in persistent storage and have their TTL extended on every write.
+
+---
+
 ## Known Limitations
 
 - **No pause/unpause** — schedules cannot be temporarily frozen. Use `forge-vesting` if pause support is required.


### PR DESCRIPTION
ScheduleCount was stored in instance storage. If instance storage expired (TTL exhausted), ScheduleCount would reset to 0. New schedules would then be assigned IDs starting from 0 again, silently overwriting existing schedules in persistent storage and permanently destroying beneficiary vesting data.

Changes:
- Move DataKey::ScheduleCount reads/writes from instance() to persistent()
- Add extend_ttl for DataKey::ScheduleCount in create_schedule() with (17280, 34560) ledgers to match other contracts
- test_schedule_ids_are_sequential_and_never_collide verifies IDs are sequential and no collision occurs across many schedules
- Document the storage strategy in the factory README

Closes #496

## Summary
[Provide a clear and concise summary of the changes made in this PR]

## Related issue
[Link to the issue, e.g., #123]
## Related Issue
[Link to the issue this PR addresses, e.g. Closes #123]

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
### Tests Performed
[Describe the tests you ran to verify your changes. Include:
- Unit tests run
- Integration tests performed
- Manual testing steps
- Any specific scenarios tested]

### Test Results
[All tests should pass. Include any test output or screenshots if relevant]

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` to format the code
- [ ] I have run `cargo clippy` to lint the code
- [ ] All new and existing tests pass locally
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the CHANGELOG.md (if applicable)
- [ ] I have labeled this PR appropriately (e.g., 'good first issue', 'documentation', 'bug')
- [ ] I have requested review from the appropriate maintainers

## Additional Notes
[Any additional context, screenshots, or information that reviewers should be aware of]
