### PR TITLE
fix: resolve compile errors blocking regression tests for #504-507

### DIFF
--- a/contracts/forge-multisig/src/lib.rs
+++ b/contracts/forge-multisig/src/lib.rs
@@ -1358,7 +1358,6 @@ mod tests {
     }
 
     #[test]
-    fn test_get_approval_count_tracks_lifecycle_through_execution() {
     fn test_get_approval_count_full_lifecycle_including_execution() {
         let env = Env::default();
         env.mock_all_auths();

--- a/contracts/forge-vesting/src/lib.rs
+++ b/contracts/forge-vesting/src/lib.rs
@@ -930,8 +930,9 @@ mod tests {
     }
 
     #[test]
-    fn test_cancel_by_admin() {
+    fn test_get_vesting_schedule_returns_correct_params() {
         let (env, contract_id, token, beneficiary, admin) = setup_with_token();
+        let client = ForgeVestingClient::new(&env, &contract_id);
         client.initialize(&token, &beneficiary, &admin, &2_500_000, &200, &5000);
 
         let schedule = client.get_vesting_schedule();
@@ -976,7 +977,6 @@ mod tests {
         let client = ForgeVestingClient::new(&env, &contract_id);
         let result = client.try_get_vesting_schedule();
         assert_eq!(result, Err(Ok(VestingError::NotInitialized)));
-    }
     }
 
     #[test]
@@ -1133,16 +1133,6 @@ mod tests {
     }
 
     #[test]
-    fn test_double_cancel_fails() {
-        let (env, contract_id, token_id, beneficiary, admin) = setup_with_token();
-        let client = ForgeVestingClient::new(&env, &contract_id);
-        client.initialize(&token_id, &beneficiary, &admin, &1_000_000, &100, &1000);
-        client.cancel();
-        let result = client.try_cancel();
-        assert_eq!(result, Err(Ok(VestingError::Cancelled)));
-    }
-
-    #[test]
     fn test_fully_vested_after_duration() {
         let (env, contract_id, token, beneficiary, admin) = setup();
         let client = ForgeVestingClient::new(&env, &contract_id);
@@ -1197,23 +1187,6 @@ mod tests {
         let s = client.get_status();
         assert_eq!(s.claimed, 5_000);
         assert_eq!(s.claimable, 0);
-    }
-
-    fn setup_with_token() -> (Env, Address, Address, Address, Address) {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, ForgeVesting);
-        let token_admin = Address::generate(&env);
-        let token_id = env
-            .register_stellar_asset_contract_v2(token_admin)
-            .address();
-        let beneficiary = Address::generate(&env);
-        let admin = Address::generate(&env);
-        {
-            soroban_sdk::token::StellarAssetClient::new(&env, &token_id)
-                .mint(&contract_id, &1_000_000);
-        }
-        (env, contract_id, token_id, beneficiary, admin)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes compile errors in `forge-multisig` and `forge-vesting` test files that were preventing the regression tests required by issues #504–#507 from building.

## Changes

### forge-multisig (issue #504)
- Fixed a duplicate function-signature bug: `test_get_approval_count_tracks_lifecycle_through_execution` had two `fn` declarations on consecutive lines. Collapsed to the correct single name `test_get_approval_count_full_lifecycle_including_execution`.
- The regression test `test_execute_double_executed_bug_regression` (issue #504) was already present and now compiles.

closes #504 

### forge-vesting (issue #506)
- Renamed broken `test_cancel_by_admin` (which called `client` before it was defined and tested `get_vesting_schedule` instead of cancel) to `test_get_vesting_schedule_returns_correct_params` and added the missing `let client = ...` line.
- Removed a stray `}` that prematurely closed the `#[cfg(test)]` module.
- Removed duplicate `test_double_cancel_fails` function.
- Removed duplicate `setup_with_token` helper function.
- The regression test `test_pause_already_paused_returns_paused_not_unauthorized` (issue #506) was already present and now compiles.

closes #506 

### forge-governor (issue #505) — no changes needed
The regression test `test_cancel_proposal_non_proposer_unauthorized_regression` was already present and correct.

closes #505 

### forge-oracle (issue #507) — no changes needed
The regression test `test_get_all_prices_never_returns_zero_price_phantom_entry` and the `continue` guard in `get_all_prices()` were already present and correct.

closes #507 

